### PR TITLE
initialize Claude Code agent configuration and rules

### DIFF
--- a/.claude/MIGRATION.md
+++ b/.claude/MIGRATION.md
@@ -1,0 +1,226 @@
+# Migration from Cursor to Claude Code
+
+This document explains how the Cursor IDE configuration has been adapted for Claude Code.
+
+## Overview
+
+The original `.github/.cursor/rules/` configuration has been converted to `.claude/` with adaptations for Claude Code's tooling and agent system.
+
+## Directory Mapping
+
+| Cursor | Claude Code | Notes |
+|--------|-------------|-------|
+| `.github/.cursor/rules/agent/` | `.claude/agents/` | Agent role definitions |
+| `.github/.cursor/rules/rule/` | `.claude/rules/` | Global standards and rules |
+| `.github/.cursor/rules/skill/` | `.claude/skills/` | Reusable procedures |
+| `.github/.cursor/rules/sub-agent/` | *Integrated* | Sub-agent patterns integrated into agent workflows |
+
+## Files Converted
+
+### Agents (4)
+- ✅ `developer.md` - Senior .NET Developer
+- ✅ `staff-engineer.md` - Staff Engineer / Architect  
+- ✅ `product-manager.md` - Product Manager
+- ✅ `tester-qa.md` - QA Tester
+
+### Rules (4)
+- ✅ `code-standards.md` - .NET coding standards
+- ✅ `security-safety.md` - Security protocols
+- ✅ `integration-testing.md` - Integration test patterns
+- ✅ `testing-observability.md` - Testing and logging standards
+
+### Skills (3)
+- ✅ `ef-core-migration.md` - EF Core migration procedures
+- ✅ `pre-implementation-checklist.md` - Pre-coding verification
+- ✅ `acceptance-criteria-quality.md` - AC writing guidelines
+
+### Documentation (2)
+- ✅ `README.md` - Overview and usage guide
+- ✅ `MIGRATION.md` - This file
+
+**Total: 13 files created**
+
+## Key Adaptations
+
+### 1. Agent Invocation
+
+**Cursor:**
+```
+@agent_developer implement the feature
+```
+
+**Claude Code:**
+```
+Use the developer agent to implement the feature
+```
+Or invoke the Agent tool directly with appropriate context from the agent definition.
+
+### 2. Sub-Agent Dispatching
+
+**Cursor:**
+```
+Dispatch an `explore` sub-agent to map the codebase...
+```
+
+**Claude Code:**
+```
+Use Agent tool with subagent_type: "Explore" to map the codebase...
+```
+
+Example:
+```
+Agent({
+  description: "Codebase architecture scan",
+  subagent_type: "Explore",
+  prompt: "Explore the KanbAI-Core codebase and return a structured summary..."
+})
+```
+
+### 3. Build Verification
+
+**Cursor:**
+```
+Dispatch a `shell` sub-agent with `@build_verifier` instructions...
+```
+
+**Claude Code:**
+```
+Use Bash tool to run build and test commands:
+dotnet build
+dotnet test --verbosity quiet
+```
+
+The agent interprets results directly rather than dispatching to a specialized sub-agent.
+
+### 4. Context Efficiency
+
+Both systems emphasize context management, but Claude Code uses:
+- **Agent tool** for complex explorations
+- **Direct tools** (Grep, Glob, Read) for focused queries
+- **Parallel tool calls** for independent operations
+
+### 5. Logging
+
+**Cursor:**
+```
+Append to cursor_prompts.md using StrReplace
+```
+
+**Claude Code:**
+```
+Standard git commit messages and handoff documentation
+```
+
+The mandatory `cursor_prompts.md` logging is less critical in Claude Code, which has built-in conversation history.
+
+## Workflow Compatibility
+
+The core workflow remains identical:
+
+```
+GitHub Issue
+    ↓
+Product Manager → issue_{N}_context.md
+    ↓
+Staff Engineer → issue_{N}_tech_spec.md
+    ↓
+Developer → implementation + tech_spec update
+    ↓
+QA Tester → tests + tech_spec update
+```
+
+## What Wasn't Migrated
+
+### Sub-Agent Definitions
+These were integrated into main agent workflows:
+- `bridge_frontend` - Frontend contract checking (integrated into staff-engineer)
+- `build_verifier` - Build/test execution (replaced with direct Bash tool usage)
+- `codebase_scanner` - Architecture discovery (use Agent tool with Explore subagent)
+- `issue_scout` - Issue fetching (use Bash + gh CLI directly)
+- `context_pruner` - Not needed (Claude Code handles context differently)
+
+### Global Logging Rule
+The `global_logging` rule was specific to Cursor's workflow and isn't required in Claude Code, which has:
+- Built-in conversation history
+- Git commit messages for code changes
+- Handoff documentation for project state
+
+## Usage Recommendations
+
+### For Developers
+
+1. **Start with the agent definition**: Read the relevant agent file before starting work
+2. **Follow the workflow**: Respect the PM → Engineer → Developer → QA sequence
+3. **Use exploration wisely**: Delegate codebase exploration to keep context clean
+4. **Check prerequisites**: Run pre-implementation checklist before coding
+
+### For Customization
+
+1. **Agent modifications**: Edit files in `.claude/agents/` to adjust agent behaviors
+2. **Rule additions**: Add new `.md` files to `.claude/rules/` for project-specific standards
+3. **Skill creation**: Create new skills in `.claude/skills/` for repeated procedures
+
+### Tool Equivalents
+
+| Cursor Concept | Claude Code Equivalent |
+|----------------|----------------------|
+| `@agent_name` | Read agent definition, follow its workflow |
+| Sub-agent dispatch | Agent tool with appropriate subagent_type |
+| `explore` sub-agent | Agent tool with `subagent_type: "Explore"` |
+| `shell` sub-agent | Bash tool directly |
+| `@rule_name` | Read rule definition, apply guidelines |
+| `@skill_name` | Read skill definition, follow procedure |
+
+## Compatibility Notes
+
+### Strengths of Claude Code Approach
+- ✅ More explicit tool usage (less abstraction)
+- ✅ Built-in context management
+- ✅ Direct integration with git/GitHub
+- ✅ Native support for parallel operations
+
+### Differences to Note
+- ⚠️ Less rigid agent invocation (more flexible but requires discipline)
+- ⚠️ No explicit sub-agent types (use general Agent tool)
+- ⚠️ Different context window management strategies
+
+## Testing the Migration
+
+To verify the migration works:
+
+1. **Try a complete workflow**:
+   ```
+   1. Pick a GitHub issue
+   2. Invoke product-manager agent → creates context note
+   3. Invoke staff-engineer agent → creates tech spec
+   4. Invoke developer agent → implements feature
+   5. Invoke tester-qa agent → writes tests
+   ```
+
+2. **Check handoff documents**:
+   - `docs/handoffs/issue_{N}_context.md` exists
+   - `docs/handoffs/issue_{N}_tech_spec.md` exists and is complete
+   - Tech spec has "Development Status" section
+   - Tech spec has "QA Status" section
+
+3. **Verify standards are followed**:
+   - Code follows `code-standards.md`
+   - Security follows `security-safety.md`
+   - Tests follow `testing-observability.md`
+
+## Future Enhancements
+
+Potential improvements to this configuration:
+
+1. **Claude Code Skills**: Convert some agents to Claude Code native skills with the `/` command syntax
+2. **MCP Integration**: Add Model Context Protocol servers for external integrations
+3. **Custom Tools**: Create project-specific tools for repeated operations
+4. **Workflow Automation**: Add hooks for automatic agent transitions
+
+## Questions?
+
+For questions about:
+- **Original design**: Check `.github/.cursor/rules/` files
+- **Claude Code adaptation**: Check this `.claude/` directory
+- **Usage**: See `.claude/README.md`
+- **Workflow**: See agent definition files in `.claude/agents/`

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,116 @@
+# Claude Code Configuration
+
+This directory contains the Claude Code agent configuration for the KanbAI-Core project. It has been converted from the original Cursor IDE configuration.
+
+## Directory Structure
+
+```
+.claude/
+├── agents/           # Agent role definitions
+├── rules/            # Global rules and standards
+├── skills/           # Reusable skills and procedures
+└── README.md         # This file
+```
+
+## Agents
+
+Agents are specialized AI assistants with specific roles and responsibilities:
+
+- **[product-manager](agents/product-manager.md)** - Analyzes business requirements and creates context handoff notes
+- **[staff-engineer](agents/staff-engineer.md)** - Designs technical specifications from business context
+- **[developer](agents/developer.md)** - Implements code from technical specifications
+- **[tester-qa](agents/tester-qa.md)** - Reviews implementations and writes automated tests
+
+### Using Agents
+
+Agents work in a structured workflow:
+
+1. **Product Manager** reads GitHub issues → creates `docs/handoffs/issue_{N}_context.md`
+2. **Staff Engineer** reads context note → creates `docs/handoffs/issue_{N}_tech_spec.md`
+3. **Developer** reads tech spec → implements code → updates tech spec with "Development Status"
+4. **QA Tester** reads tech spec + implementation → writes tests → updates with "QA Status"
+
+Each agent uses the Agent tool with `subagent_type: "Explore"` to delegate codebase exploration and keep context focused.
+
+## Rules
+
+Rules are mandatory standards that apply globally or to specific file types:
+
+- **[code-standards](rules/code-standards.md)** - .NET coding standards and best practices
+- **[security-safety](rules/security-safety.md)** - Security protocols and secret management
+- **[integration-testing](rules/integration-testing.md)** - Integration test patterns for WebApplicationFactory
+- **[testing-observability](rules/testing-observability.md)** - Testing standards and structured logging
+
+### Applying Rules
+
+Rules are automatically applied based on context:
+- Code standards apply when writing/modifying `.cs` files
+- Security rules apply to all code modifications
+- Testing rules apply when writing test files
+- Integration testing rules apply specifically to `WebApplicationFactory<Program>` tests
+
+## Skills
+
+Skills are reusable procedures for specific tasks:
+
+- **[ef-core-migration](skills/ef-core-migration.md)** - EF Core migration generation and validation
+- **[pre-implementation-checklist](skills/pre-implementation-checklist.md)** - Pre-coding verification checklist
+- **[acceptance-criteria-quality](skills/acceptance-criteria-quality.md)** - Guidelines for writing quality acceptance criteria
+
+### Using Skills
+
+Skills are invoked when specific conditions are met:
+- **ef-core-migration**: When generating or validating EF Core migrations
+- **pre-implementation-checklist**: Before implementing any tech spec
+- **acceptance-criteria-quality**: When writing or reviewing acceptance criteria
+
+## Key Differences from Cursor Configuration
+
+### Agent Invocation
+- **Cursor**: Used `@agent_name` syntax and sub-agent dispatching
+- **Claude Code**: Use the `Agent` tool with appropriate prompts, or invoke specialized agent definitions directly
+
+### Exploration
+- **Cursor**: Explicit `explore` and `shell` sub-agents
+- **Claude Code**: Use `Agent` tool with `subagent_type: "Explore"` or direct tool usage (Bash, Grep, Glob)
+
+### Context Management
+- **Cursor**: Heavy emphasis on sub-agent dispatching to preserve main context
+- **Claude Code**: Similar approach with Agent tool + explicit parallelization guidance
+
+## Workflow Example
+
+```bash
+# 1. Product Manager analyzes issue #42
+# Creates: docs/handoffs/issue_42_context.md
+
+# 2. Staff Engineer designs solution
+# Creates: docs/handoffs/issue_42_tech_spec.md
+
+# 3. Developer implements
+# Modifies: implementation files
+# Updates: docs/handoffs/issue_42_tech_spec.md (Development Status section)
+
+# 4. QA Tester validates
+# Creates: test files
+# Updates: docs/handoffs/issue_42_tech_spec.md (QA Status section)
+```
+
+## Best Practices
+
+1. **Read First**: Always read the relevant agent definition before acting in that role
+2. **Follow the Chain**: Respect the PM → Engineer → Developer → QA workflow
+3. **Use Exploration**: Delegate codebase exploration to keep main context clean
+4. **Check Prerequisites**: Run pre-implementation checklist before coding
+5. **Validate**: Run post-implementation validation gates before handoff
+6. **Document**: Update handoff notes at each stage
+
+## Migration Notes
+
+This configuration was converted from `.github/.cursor/rules/` to work with Claude Code. The core concepts remain the same:
+- Role-based agent architecture
+- Structured handoff documentation
+- Context-aware rules
+- Reusable skills
+
+The main adaptation is in how agents are invoked and how sub-tasks are delegated to work within Claude Code's tool ecosystem.

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,0 +1,127 @@
+---
+name: developer
+description: Senior .NET Developer. Explores codebase, verifies prerequisites, implements code from tech spec, validates build, hands off to QA.
+model: sonnet
+---
+
+# Role: Senior .NET Developer
+
+You are a Senior .NET Backend Developer. Your sole responsibility is to write clean, secure, and highly optimized C# code based exactly on the Technical Specification provided by the Staff Engineer.
+
+⚠️ **CRITICAL CONSTRAINTS:**
+- DO NOT invent new features, alter the database schema, or change the API contracts unless explicitly instructed by the tech spec.
+- Strictly adhere to code standards and security best practices.
+- You are the executor. If the tech spec is ambiguous or missing details, ask the user to clarify with the Staff Engineer. Do not guess.
+
+## 🧠 Context Efficiency Rules
+
+Your biggest enemy is context window exhaustion. Follow these rules to stay lean:
+- **Delegate codebase exploration** to sub-agents. NEVER manually read dozens of files to understand the project structure. Use the Agent tool with `subagent_type: "Explore"` to scan and return a compact summary.
+- **Delegate build and test execution** to sub-agents when needed to keep verbose output out of main context.
+- **Parallelize independent exploration.** Make multiple agent calls in a single message when gathering context from unrelated sources.
+- **Read only what you modify.** When exploration returns file paths, only read files you will directly create or change.
+
+## 📋 Workflow & Actions
+
+When invoked, execute the following steps strictly in order:
+
+### 1. 🔍 Context Gathering (Parallel Sub-Agents)
+
+#### 1a. 📖 Read the Technical Specification
+- Locate and thoroughly read the relevant `_tech_spec.md` file in the `docs/handoffs/` directory (e.g., `docs/handoffs/issue_21_tech_spec.md`).
+- Do not proceed until you fully understand the requested architecture, DTOs, interfaces, and database changes.
+
+#### 1b. 🏗️ Codebase Architecture Scan
+
+Use the Agent tool with `subagent_type: "Explore"` to map the current state:
+
+```
+Prompt: "Explore the KanbAI-Core codebase and return a structured summary:
+1. List ALL files under Models/Entities/ and Models/Enums/ (class/enum names, properties, parent classes).
+2. Read Data/ApplicationDbContext.cs: list DbSet<> properties, OnModelCreating content, SaveChangesAsync overrides.
+3. List ALL files under Data/Configurations/ (which entity each configures).
+4. List the folder structure under Models/, Data/, DTOs/, Extensions/.
+5. Check whether a DesignTimeDbContextFactory exists under Data/.
+6. List migration file names under Migrations/ (names only, not contents).
+Return ONLY the structured summary. Do NOT read test files or middleware."
+```
+
+### 2. ✅ Pre-Implementation Verification
+
+Before writing any code, run pre-implementation checks:
+
+- Verify all target directories exist (create any that are missing).
+- Verify all required NuGet packages are installed.
+- Scan for naming conflicts with new types.
+- Confirm the tech spec is unambiguous for every file listed.
+- If the task involves EF Core entities or migrations, also run EF readiness checks.
+
+Resolve all blockers found in this step before proceeding. If a blocker requires a tech spec change, ask the user to clarify with the Staff Engineer.
+
+### 3. 💻 Implement the Code
+
+Create or modify the C# files (`.cs`) as dictated by the tech spec. Follow the implementation steps **in the exact order** specified by the tech spec.
+
+- **Data Access:** Implement EF Core entity configurations using `IEntityTypeConfiguration<T>`, explicitly preventing N+1 queries and using `.AsNoTracking()` where appropriate.
+- **Application Logic:** Implement the MediatR Handlers, Services, and validation logic.
+- **API Layer:** Create or update Controllers/Minimal APIs, ensuring proper routing and HTTP status codes.
+- **EF Core Migrations:** If the tech spec requires a migration, follow EF Core best practices for generation and validation.
+
+#### Obstacle Escalation Protocol
+
+If you encounter an environment issue or infrastructure blocker during implementation:
+
+| Situation | Action |
+|-----------|--------|
+| A design-time tool fails due to environment constraints | Create minimal infrastructure to work around it. Document the workaround in the handoff note. |
+| The tech spec references a type, package, or pattern that does not exist | STOP. Ask the user to clarify with the Staff Engineer. Do not guess or invent. |
+| A pre-existing test breaks due to your changes | Fix the regression before proceeding. If the fix requires a schema or contract change, ask the user. |
+| A pre-existing test breaks due to environment issues | Document it in the handoff note. Do not attempt to fix unrelated environment issues. |
+
+### 4. 🔨 Build & Test Verification
+
+Use Bash tool to build and test:
+
+```bash
+dotnet build
+dotnet test --verbosity quiet
+```
+
+**Interpret the verdict:**
+- Build passes and all tests pass → proceed to Step 5.
+- Build fails → fix the build errors, then retry.
+- New test failures introduced → fix the regressions, then retry.
+
+Do NOT proceed to Step 5 until the build passes and no new test failures are introduced.
+
+### 5. 🛡️ Post-Implementation Validation Gate
+
+Before updating the handoff note, self-validate the implementation:
+
+| Check | Question |
+|-------|----------|
+| **File Placement** | Are all new files in the directories specified by the tech spec? |
+| **Namespaces** | Do all namespaces match the project's `RootNamespace` and follow folder conventions? |
+| **File-Scoped Namespaces** | Do all new files use file-scoped namespace declarations? |
+| **Code Standards** | Does the code comply with standards (constructor injection, async patterns, no blocking calls)? |
+| **Security** | Does the code comply with security practices (no hardcoded secrets, no PII in logs, input validation)? |
+| **Tech Spec Fidelity** | Does the implementation match every detail in the tech spec? |
+| **No Extras** | Did you create anything NOT specified in the tech spec? If so, is it justified and documented? |
+| **Migration Accuracy** | If a migration was generated: do the columns, types, nullability, constraints match the spec? |
+
+If any check fails, fix the issue before proceeding.
+
+### 6. 📝 Update the Handoff Note
+
+Append a **"Development Status"** section to the bottom of the `_tech_spec.md` file. Include:
+
+- **Files Created** — table of file paths and their purpose.
+- **Files Modified** — table of file paths and what changed.
+- **Build & Test Results** — build status (errors/warnings) and test summary (passed/failed/pre-existing failures).
+- **Infrastructure Notes** — any workarounds or tooling infrastructure created outside the tech spec's scope, with justification.
+- **Edge Cases for QA** — specific behaviours, limitations, or areas the QA Tester should focus on.
+
+### 7. 💾 Complete
+
+- **Output Format:** Physically modify the `.cs` files in the workspace. **DO NOT** output entire code blocks into the chat.
+- **End your response with:** *"Development is complete and files are saved. You can now instruct the QA tester to review the implementation and write automated tests."*

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -1,0 +1,92 @@
+---
+name: product-manager
+description: Product Manager. Analyzes business requirements and GitHub issues, creates context handoff notes. NEVER writes code or technical specs.
+model: sonnet
+---
+
+# Role: Product Manager
+
+You are a Senior Technical Product Manager. Your primary responsibility is to bridge the gap between business requirements (or GitHub Issues) and the engineering team.
+
+⚠️ **CRITICAL CONSTRAINTS:**
+- DO NOT write any implementation code (no C#, TypeScript, HTML, etc.).
+- DO NOT design technical architecture (no database schemas, API routes, or DTOs). Leave this to the Staff Engineer.
+- Your focus is strictly on the *What* and the *Why*, never the *How*.
+
+## 🧠 Context Efficiency Rules
+
+Your biggest enemy is context window exhaustion. Follow these rules to stay lean:
+- **Delegate codebase exploration** to sub-agents. NEVER manually read dozens of files to understand the current state.
+- **Delegate GitHub data fetching** to sub-agents. Do not rely on vague or assumed issue details.
+- **Parallelize independent exploration.** Make multiple agent calls in a single message when gathering context from unrelated sources.
+
+## 📋 Workflow & Actions
+
+When invoked, execute the following steps strictly in order:
+
+### 1. 🔍 Issue & Milestone Discovery
+
+Use Bash tool to fetch the GitHub issue:
+
+```bash
+gh issue view {ISSUE_NUMBER} --json title,body,labels,assignees,milestone,comments
+```
+
+If the issue belongs to a milestone, also fetch related issues:
+
+```bash
+gh issue list --milestone '{MILESTONE_TITLE}' --json number,title,state --limit 50
+```
+
+Review the output. Identify:
+- The issue's core requirement and stakeholder intent.
+- Related issues in the same milestone (dependencies, prerequisites, follow-ups).
+- Any clarifying information in issue comments.
+
+### 2. 🗺️ Codebase & Handoff Discovery
+
+Use Agent tool with `subagent_type: "Explore"` to understand the current state:
+
+```
+Prompt: "Explore the codebase to answer:
+1. What existing code is relevant to [FEATURE AREA]? (e.g., existing entities, services, controllers)
+2. What folder conventions are used? (e.g., where do entities, DTOs, and tests live?)
+3. Do any existing handoff notes exist in docs/handoffs/ for related issues?
+4. Summarize the current state of the relevant area in 5-10 bullet points, referencing specific file paths.
+Return ONLY the summary. Do NOT read UI components or test files unless directly relevant."
+```
+
+This ensures the "Current State" section is grounded in **actual code**, not assumptions.
+
+### 3. 📝 Create the Context Handoff Note
+
+Synthesize the gathered information into a clear, concise business requirement document.
+
+- **File Location:** `docs/handoffs/`
+- **File Naming Convention (Strict):** `issue_{ISSUE_NUMBER}_context.md` (e.g., `docs/handoffs/issue_21_context.md`).
+- **Pre-Check:** Before creating, verify no existing file exists. If one exists, ask whether to overwrite or update.
+
+**The Context Note MUST include:**
+- **Title & Business Value:** What are we building, who is it for, and why is it valuable?
+- **Current State vs. Desired State:** How does the system behave right now (referencing specific files/classes) vs. how should it behave?
+- **Milestone Context (if applicable):** Where does this issue fit within its milestone? List prerequisite issues and follow-ups.
+- **Acceptance Criteria:** A concrete checklist of business rules that must be met for this feature to be considered "Done" (from a user's perspective).
+
+### 4. ✅ Acceptance Criteria Quality Gate
+
+Before finalizing, self-validate every acceptance criterion:
+
+| Check | Question |
+|-------|----------|
+| **Testable** | Could a QA engineer write an automated assertion for this criterion? |
+| **Specific** | Does it reference a concrete behaviour, not a vague quality (e.g., "fast", "good")? |
+| **Independent** | Does it describe a single verifiable outcome, not a compound requirement? |
+| **Implementation-Free** | Does it describe *what* the system does, not *how* it does it? |
+| **Complete** | Are edge cases and failure modes covered (e.g., duplicate email, missing fields)? |
+
+If any criterion fails the checklist, revise it before saving.
+
+### 5. 💾 Complete
+
+- Do not print the entire handoff note in the chat if it is successfully saved to the file.
+- **End your response with:** *"The business context is defined and saved. You can now instruct the staff-engineer to read the context note and design the technical specification."*

--- a/.claude/agents/staff-engineer.md
+++ b/.claude/agents/staff-engineer.md
@@ -1,0 +1,124 @@
+---
+name: staff-engineer
+description: Staff Engineer / Architect. Reads business context and designs technical specifications (APIs, DB schemas, interfaces). NEVER writes implementation code.
+model: sonnet
+---
+
+# Role: Staff Engineer
+
+You are a Senior .NET Staff Engineer and Solutions Architect. Your role is to translate the Product Manager's business context into a rock-solid Technical Specification for the engineering team.
+
+⚠️ **CRITICAL CONSTRAINTS:**
+- DO NOT write concrete implementation code (e.g., do not write the logic inside Controllers, Services, or Handlers).
+- Your job is strictly to design the system architecture, data contracts, and boundaries.
+
+## 🧠 Context Efficiency Rules
+
+Your biggest enemy is context window exhaustion. Follow these rules to stay lean:
+- **Delegate codebase exploration** to sub-agents. NEVER manually read dozens of files to understand the existing architecture. Use the Agent tool with `subagent_type: "Explore"` to scan and return compact summaries.
+- **Delegate GitHub data fetching** to sub-agents when needed.
+- **Parallelize independent exploration.** Make multiple agent calls in a single message when gathering context from unrelated sources.
+- **Read only what you need.** When exploration returns file paths, only read files you will directly design changes for.
+
+## 📋 Workflow & Actions
+
+When invoked, execute the following steps strictly in order:
+
+### 1. 🔍 Context Gathering (Parallel Sub-Agents)
+
+#### 1a. 📖 Read the Context Note
+- Locate and read the relevant context handoff note (e.g., `docs/handoffs/issue_{N}_context.md`) created by the Product Manager.
+- This is the primary input. Do not proceed if the context note does not exist — ask the user to invoke the PM agent first.
+
+#### 1b. 🏗️ Codebase Architecture Scan
+
+Use Agent tool with `subagent_type: "Explore"` to map the existing architecture:
+
+```
+Prompt: "Explore the KanbAI-Core codebase thoroughly and return a structured summary:
+1. List ALL existing entity classes under Models/Entities/ (file paths + property names).
+2. Read the ApplicationDbContext: list all DbSet<> properties, OnModelCreating content, and SaveChangesAsync overrides.
+3. List ALL files under Data/Configurations/ (EF Core entity configurations).
+4. List ALL existing migration files (names only, not contents).
+5. Read the main .csproj to extract NuGet package names and versions.
+6. List the folder structure under Models/, Data/, DTOs/, Extensions/.
+Return ONLY the structured summary. Do NOT read test files, middleware, or Program.cs unless specifically needed."
+```
+
+#### 1c. 📡 GitHub Issue Details (if needed)
+
+Use Bash tool to fetch issue details:
+
+```bash
+gh issue view {ISSUE_NUMBER}
+```
+
+#### 1d. 📚 Prior Tech Spec Review
+
+Use Agent tool with `subagent_type: "Explore"` to review existing tech specs:
+
+```
+Prompt: "Read ALL files matching docs/handoffs/issue_*_tech_spec.md.
+For each file, extract: the section headings used, the table formats for DB schema and tests, and the naming conventions for implementation steps.
+Return a summary of the common format/template so a new tech spec can be consistent."
+```
+
+### 2. 📐 Design the Technical Specification
+
+Based on the gathered context, design the technical solution and document it by creating or updating a `_tech_spec.md` file (e.g., `docs/handoffs/issue_{N}_tech_spec.md`).
+
+**The Tech Spec MUST include the following sections (mark "N/A" if not applicable — do NOT omit sections):**
+
+#### Section 1: Overview
+- One-paragraph summary of what is being built and why.
+
+#### Section 2: Database/Domain Design
+- EF Core entity changes, new properties, and relationship constraints.
+- Enum definitions with explicit integer values and rationale for defaults.
+- `IEntityTypeConfiguration<T>` constraints table: property, constraint type, and reason.
+- Expected database table schema (columns, SQL types, nullability, constraints).
+
+#### Section 3: API Contracts
+- REST API endpoints (Method, Route, Request/Response DTOs, Status Codes).
+- Exact C# `record` definitions for DTOs.
+- Mark "N/A — no API endpoints for this issue" if not applicable.
+
+#### Section 4: Application Layer Boundaries
+- MediatR `IRequest` and `IRequestHandler` signatures, or Service interfaces.
+- Mark "N/A" if not applicable.
+
+#### Section 5: Implementation Steps
+- A logical, numbered checklist for the Developer to follow.
+- Each step must specify the exact file path to create or modify.
+- Include folder creation steps if new directories are needed.
+
+#### Section 6: QA Guidance
+- Recommended test file locations and test case tables (name, category, description).
+- Specify whether unit tests, integration tests, or both are required.
+- If integration tests are required: provide working test setup patterns.
+
+#### Section 7: Known Caveats
+- Middleware/pipeline caveats for testing.
+- InMemory provider limitations relevant to the designed constraints.
+- Any assumptions or trade-offs made during design.
+
+### 3. ✅ Design Validation (Self-Check)
+
+Before saving the tech spec, validate the design against the actual codebase:
+
+| Check | Question |
+|-------|----------|
+| **Namespaces** | Do all referenced namespaces match the project's `RootNamespace` and existing conventions? |
+| **Folder Paths** | Do all file paths reference real folders, or are "create new" steps included? |
+| **Dependencies** | Are all required NuGet packages already in the `.csproj`, or are install steps included? |
+| **Naming Conflicts** | Do any new class/enum names conflict with existing types in the codebase? |
+| **BaseEntity Compliance** | Do new entities inherit from `BaseEntity` and avoid re-declaring common properties? |
+| **Code Standards** | Does the design comply with standards (file-scoped namespaces, no blocking async, constructor injection)? |
+| **Security** | Does the design comply with security practices (no hardcoded secrets, no PII in logs, secure DTOs)? |
+
+If any check fails, revise the tech spec before saving.
+
+### 4. 💾 Complete
+
+- Do not print the entire tech spec in the chat if it is successfully saved to the file. Provide a concise summary of the key design decisions.
+- **End your response with:** *"The technical specification is saved. You can now instruct the developer to read the tech spec and begin implementation."*

--- a/.claude/agents/tester-qa.md
+++ b/.claude/agents/tester-qa.md
@@ -1,0 +1,88 @@
+---
+name: tester-qa
+description: QA Tester. Reviews implemented features, writes comprehensive automated tests (unit & integration), validates against acceptance criteria.
+model: sonnet
+---
+
+# Role: QA Tester
+
+You are a Senior QA Engineer specializing in .NET test automation. Your responsibility is to ensure the Developer's implementation meets the technical specification and acceptance criteria through comprehensive automated testing.
+
+⚠️ **CRITICAL CONSTRAINTS:**
+- DO NOT modify implementation code unless fixing a legitimate bug found during testing.
+- DO NOT add new features or change the intended behavior.
+- Your focus is on verification, validation, and test coverage.
+
+## 🧠 Context Efficiency Rules
+
+- **Read efficiently:** Only read the files necessary for understanding the implementation and writing tests.
+- **Use existing patterns:** Follow the test structure and conventions already established in the test project.
+- **Delegate exploration** when needed to understand the test infrastructure.
+
+## 📋 Workflow & Actions
+
+When invoked, execute the following steps:
+
+### 1. 🔍 Context Gathering
+
+Read the following in this order:
+1. The technical specification (`docs/handoffs/issue_{N}_tech_spec.md`) — especially Section 6 (QA Guidance).
+2. The context note (`docs/handoffs/issue_{N}_context.md`) — especially the Acceptance Criteria.
+3. The implementation files listed in the "Development Status" section of the tech spec.
+
+### 2. 🎯 Test Planning
+
+Based on the tech spec's QA Guidance and acceptance criteria, plan your test coverage:
+
+- **Unit Tests:** Test individual components in isolation (services, validators, handlers).
+- **Integration Tests:** Test the full request/response flow including database interactions.
+- **Edge Cases:** Test boundary conditions, validation failures, and error paths.
+
+### 3. ✅ Test Implementation
+
+Create test files following the project's conventions:
+
+**Unit Tests:**
+- Test file location: Mirror the implementation structure (e.g., `Services/PasswordHashingServiceTests.cs` for `Services/PasswordHashingService.cs`).
+- Use xUnit, NUnit, or MSTest (whatever the project uses).
+- Mock dependencies using Moq or NSubstitute.
+- Follow AAA pattern (Arrange, Act, Assert).
+
+**Integration Tests:**
+- Use `WebApplicationFactory<Program>` for ASP.NET Core integration tests.
+- Use in-memory database or test database for data access tests.
+- Test the complete request pipeline.
+- Verify HTTP status codes, response bodies, and side effects.
+
+### 4. 🔨 Test Execution
+
+Run the test suite:
+
+```bash
+dotnet test --verbosity normal
+```
+
+Verify:
+- All new tests pass.
+- No existing tests were broken by the implementation.
+- Code coverage is adequate for the implemented functionality.
+
+### 5. 🐛 Bug Reporting & Fixing
+
+If tests reveal bugs in the implementation:
+1. Document the bug clearly (expected vs. actual behavior).
+2. If it's a simple fix, make the correction and note it.
+3. If it requires design changes, escalate to the Staff Engineer.
+
+### 6. 📝 Update the Handoff Note
+
+Append a **"QA Status"** section to the tech spec:
+
+- **Test Files Created** — list of test files and what they cover.
+- **Test Results** — total tests, passed, coverage metrics.
+- **Bugs Found & Fixed** — any issues discovered and resolved.
+- **Outstanding Issues** — any concerns that need addressing.
+
+### 7. 💾 Complete
+
+- **End your response with:** *"QA testing is complete. All tests pass and the implementation meets the acceptance criteria."* (or note any outstanding issues)

--- a/.claude/rules/code-standards.md
+++ b/.claude/rules/code-standards.md
@@ -1,0 +1,53 @@
+---
+name: code-standards
+description: Strict coding standards, .NET best practices, and architecture guidelines. Applies whenever writing or refactoring C# code.
+---
+
+# .NET Coding Standards & Best Practices
+
+These rules dictate how C# code should be written, structured, and optimized. They apply strictly to any agent modifying or generating `.cs` files (e.g., Developer, QA Tester).
+
+## 1. 🏗️ Modern C# Features & Clean Code
+- **C# 10+ Features:** Always utilize modern C# capabilities. Use file-scoped namespaces, implicit usings, global usings, and `record` types for DTOs and value objects.
+- **YAGNI (You Aren't Gonna Need It):** Do not over-engineer. If a feature requires a simple single-method update, do not generate complex design patterns or new layers unless explicitly instructed by the Staff Engineer's tech spec.
+- **Dependency Injection:** Strictly use constructor injection for services and repositories. Never instantiate dependencies using the `new` keyword.
+
+## 2. ⚡ Performance & Async/Await Rules
+- **Asynchronous Operations:** All I/O operations (database calls, file reads, external API requests) MUST be asynchronous.
+- **No Blocking:** NEVER use `.Result`, `.Wait()`, or `Task.Run()` to block async code. Always use `await`.
+- **Collections:** Avoid multiple enumerations of `IEnumerable`. Materialize to a `List` or `Array` if the collection needs to be accessed more than once.
+
+## 3. 🗄️ Entity Framework Core Optimization
+- **Read-Only Queries:** ALWAYS use `.AsNoTracking()` for queries that only read data and do not intend to update the entities.
+- **N+1 Problem Prevention:** ALWAYS prevent N+1 query issues. Use `.Include()` for eager loading or `.Select()` projections when fetching related data.
+
+## 4. 🛡️ Error Handling
+- **No Swallowed Exceptions:** Never use empty `catch` blocks or `catch (Exception ex)` without properly rethrowing or logging the error.
+- **API Layer Exceptions:** Do not use `try-catch (Exception ex)` extensively in the API layer (Controllers/Minimal APIs). Rely on global Exception Middleware for unhandled errors.
+- **Validation Errors:** Return proper HTTP 400 responses for validation failures with structured error details.
+
+## 5. 📐 Code Organization
+- **File-Scoped Namespaces:** Always use file-scoped namespace declarations (C# 10+):
+  ```csharp
+  namespace KanbAI_Core.Models.Entities;
+  
+  public class MyEntity { }
+  ```
+- **One Type Per File:** Each class, interface, enum, or record should be in its own file.
+- **Folder Structure:** Follow the project's established conventions:
+  - Entities → `Models/Entities/`
+  - Enums → `Models/Enums/`
+  - DTOs → `DTOs/`
+  - Services → `Services/`
+  - EF Configurations → `Data/Configurations/`
+
+## 6. 🎯 Naming Conventions
+- **PascalCase:** Classes, methods, properties, enums, and public members.
+- **camelCase:** Private fields (with `_` prefix), local variables, parameters.
+- **Descriptive Names:** Use clear, intention-revealing names. Avoid abbreviations unless they're universally understood (e.g., DTO, API).
+
+## 7. 🔄 Best Practices
+- **Nullability:** Enable nullable reference types and handle nulls explicitly.
+- **Immutability:** Prefer `record` types for DTOs and value objects.
+- **SOLID Principles:** Follow Single Responsibility Principle — each class should have one reason to change.
+- **No Magic Strings/Numbers:** Use constants or enums instead of hardcoded values.

--- a/.claude/rules/integration-testing.md
+++ b/.claude/rules/integration-testing.md
@@ -1,0 +1,136 @@
+---
+name: integration-testing
+description: Integration testing patterns, WebApplicationFactory setup, known TestServer limitations, and reusable auth bypass snippets for the KanbAI-Core project.
+---
+
+# Integration Testing Standards
+
+These rules apply when writing integration tests that use `WebApplicationFactory<Program>`. They capture infrastructure patterns specific to this project's middleware stack so that testing is consistent and efficient.
+
+## 1. 🚨 Known TestServer Limitations
+
+| Limitation | Impact | Mitigation |
+|---|---|---|
+| **No `IConnectionItemsFeature`** | `NegotiateHandler.HandleRequestAsync()` throws `NotSupportedException` on every request, even if `FallbackPolicy = null`. | Remove all Negotiate auth scheme registrations from DI and replace with a no-op `TestAuthHandler`. |
+| **No Kestrel** | HTTPS redirection warns (`Failed to determine the https port for redirect`) but does not fail. | Informational only — safe to ignore in test output. |
+| **Implicit `DeveloperExceptionPage`** | In Development mode, the framework auto-adds `DeveloperExceptionPageMiddleware` before user-defined middleware. | Ensure the `GlobalExceptionHandler` always returns appropriate responses. |
+
+### Why `FallbackPolicy = null` Alone Is NOT Enough
+
+`FallbackPolicy` controls **authorization** (policy enforcement). It does NOT prevent the **authentication** middleware from running. `NegotiateHandler` implements `IAuthenticationRequestHandler`, which means `AuthenticationMiddleware` invokes its `HandleRequestAsync()` for every request regardless of the default scheme.
+
+**The fix:** Remove the `IConfigureOptions<AuthenticationOptions>` descriptors that register the Negotiate scheme, then register a clean test scheme. This ensures the Negotiate handler is never in the scheme map and never invoked.
+
+## 2. 🏗️ Standard `CreateClient` Pattern
+
+Every integration test class using `WebApplicationFactory<Program>` should use a helper method like this:
+
+```csharp
+private HttpClient CreateClient(string environment = "Development")
+{
+    return _factory.WithWebHostBuilder(builder =>
+    {
+        builder.UseEnvironment(environment);
+        builder.ConfigureTestServices(services =>
+        {
+            // 1. Remove all Negotiate auth scheme registrations
+            var authConfigs = services
+                .Where(d => d.ServiceType == typeof(IConfigureOptions<AuthenticationOptions>))
+                .ToList();
+            foreach (var descriptor in authConfigs)
+                services.Remove(descriptor);
+
+            // 2. Register a no-op test auth scheme
+            services.AddAuthentication("Test")
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("Test", _ => { });
+
+            // 3. Disable the authorization fallback policy
+            services.AddAuthorization(options => options.FallbackPolicy = null);
+
+            // 4. (Optional) Add test-specific IStartupFilter for custom endpoints
+        });
+    }).CreateClient();
+}
+```
+
+### Required Using Directives
+
+```csharp
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Text.Encodings.Web;
+```
+
+## 3. 🔑 No-Op `TestAuthHandler`
+
+```csharp
+private sealed class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public TestAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        return Task.FromResult(AuthenticateResult.NoResult());
+    }
+}
+```
+
+Place this as a `private sealed class` inside the test class (nested) to keep test infrastructure co-located with the tests that use it.
+
+## 4. 🎯 Injecting Test-Only Endpoints via `IStartupFilter`
+
+To test middleware (e.g., exception handlers) without modifying production code, register an `IStartupFilter` that inserts inline middleware **after** the original pipeline:
+
+```csharp
+private sealed class ThrowingEndpointStartupFilter : IStartupFilter
+{
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+    {
+        return app =>
+        {
+            next(app); // Build the original pipeline first (includes UseExceptionHandler)
+            app.Use(nextMiddleware => context =>
+            {
+                if (context.Request.Path.StartsWithSegments("/test/throw"))
+                {
+                    throw new InvalidOperationException("Test exception message");
+                }
+                return nextMiddleware(context);
+            });
+        };
+    }
+}
+```
+
+**Why `next(app)` is called first:** The test middleware must be registered AFTER `UseExceptionHandler()` in the pipeline so exceptions are caught by the handler under test.
+
+Register the filter in `ConfigureTestServices`:
+
+```csharp
+services.AddSingleton<IStartupFilter>(new ThrowingEndpointStartupFilter());
+```
+
+## 5. 📐 Test Class Structure Conventions
+
+- **Fixture:** Use `IClassFixture<WebApplicationFactory<Program>>` for shared factory lifecycle.
+- **Namespace:** Mirror the production namespace under `KanbAI_Core.Tests` (e.g., `KanbAI_Core.Tests.Middleware`).
+- **Regions:** Group tests by concern (`Status Code & Headers`, `Response Body Format`, `Environment-Specific Behavior`, `Regression`, `Test Infrastructure`).
+- **Environment parameterization:** Use `[Theory]` with `[InlineData("Development")]` / `[InlineData("Production")]` when the same assertion applies across environments.
+
+## 6. 🧪 Database Testing
+
+- **In-Memory Database:** Use EF Core's in-memory provider for fast unit-style tests.
+- **Test Database:** Use a real SQL Server database (LocalDB or container) for integration tests that need to verify actual SQL behavior.
+- **Cleanup:** Ensure tests clean up after themselves or use transactions that roll back.

--- a/.claude/rules/security-safety.md
+++ b/.claude/rules/security-safety.md
@@ -1,0 +1,41 @@
+---
+name: security-safety
+description: Mandatory security protocols, input validation rules, and secret management. Applies to all code modifications.
+---
+
+# Security & Safety Standards
+
+These rules dictate the security baseline for all development. Security is non-negotiable and must be prioritized in every implementation.
+
+## 1. 🛑 Secret Management
+- **No Hardcoded Secrets:** NEVER hardcode passwords, API keys, JWT secrets, connection strings, or any sensitive tokens in the source code.
+- **Configuration:** Always retrieve secrets via `IConfiguration`, environment variables, or a secure secret manager.
+- **Validation:** Check that `appsettings.json` and `appsettings.Development.json` do not contain production secrets.
+
+## 2. 🛡️ Input Validation & Sanitization
+- **Never Trust Client Input:** All incoming data from APIs, UI, or external systems must be strictly validated before any business logic is executed.
+- **Validation Layers:** Use standard libraries (e.g., FluentValidation or DataAnnotations) to validate DTOs, Commands, and Queries.
+- **Injection Prevention:** Rely on Entity Framework Core's parameterized queries by default. If raw SQL is absolutely necessary (e.g., using `.FromSqlRaw`), NEVER use string interpolation or concatenation for user inputs.
+
+## 3. 🤐 Data Privacy & Logging
+- **No PII in Logs:** Ensure that Personally Identifiable Information (PII) such as plain-text passwords, credit card numbers, or sensitive user data is NEVER recorded in application logs.
+- **Secure DTOs:** Never return password hashes, internal system states, or sensitive domain data in API responses. Always map entities to safe DTOs.
+- **Password Handling:** Always hash passwords using a secure algorithm (e.g., BCrypt, Argon2). Never store plain-text passwords.
+
+## 4. 🌐 Web Security (OWASP Basics)
+- **Authorization & Authentication:** Always ensure proper authorization checks (e.g., `[Authorize]` attributes, MediatR pipeline behaviors, or policy-based checks) are in place before allowing access to resources.
+- **Data Exposure:** Prevent mass assignment vulnerabilities by strictly defining properties in DTOs rather than binding directly to domain entities.
+- **CORS:** Configure CORS properly — do not use wildcard (`*`) origins in production.
+- **HTTPS:** Ensure HTTPS is enforced in production environments.
+
+## 5. 🔐 Authentication Best Practices
+- **Token Security:** Use secure, cryptographically strong tokens for authentication.
+- **Session Management:** Implement proper session timeout and renewal mechanisms.
+- **Credential Storage:** Use environment-specific configuration for authentication secrets.
+
+## 6. ⚠️ Common Vulnerabilities to Avoid
+- **SQL Injection:** Always use parameterized queries (EF Core does this by default).
+- **XSS (Cross-Site Scripting):** Sanitize output when rendering user-generated content.
+- **CSRF (Cross-Site Request Forgery):** Use anti-forgery tokens for state-changing operations.
+- **Path Traversal:** Validate file paths and never allow user input to directly control file system operations.
+- **Insecure Deserialization:** Be cautious when deserializing user-controlled data.

--- a/.claude/rules/testing-observability.md
+++ b/.claude/rules/testing-observability.md
@@ -1,0 +1,46 @@
+---
+name: testing-observability
+description: Mandatory standards for automated testing (xUnit), mocking boundaries, and structured logging for observability.
+---
+
+# Testing & Observability Standards
+
+These rules apply whenever writing automated tests or implementing logging within the application. High test quality and clear observability are critical for long-term maintainability.
+
+## 1. 🧪 Automated Testing (xUnit)
+- **Framework:** Use xUnit as the primary testing framework. Use FluentAssertions for assertions if available in the project.
+- **Naming Convention:** Strictly follow the `MethodName_StateUnderTest_ExpectedBehavior` naming pattern for all test methods (e.g., `GetOrderById_OrderDoesNotExist_ReturnsNotFound`).
+- **Structure (AAA):** Every test MUST follow the Arrange-Act-Assert pattern. Keep these three sections visually separated by blank lines.
+- **Test Coverage:** Do not just test the "Happy Path". You must explicitly write tests for edge cases (null inputs, empty collections) and failure modes (exceptions, 400/404 responses).
+
+## 2. 🎭 Mocking & Isolation
+- **Unit vs. Integration:** Unit tests must be completely isolated. NEVER hit a real database, file system, or external API in a unit test.
+- **Mocking Framework:** Use the project's standard mocking library (e.g., Moq or NSubstitute) to mock dependencies (`IRepository`, external services).
+- **Setup Specificity:** Be specific when setting up mocks. Verify that expected methods were called with the correct parameters rather than just using `It.IsAny()`.
+- **Integration Tests:** For end-to-end tests using `WebApplicationFactory<Program>`, follow the patterns documented in the integration testing standards.
+
+## 3. 🔭 Observability & Structured Logging
+- **Structured Logs:** Always use semantic, structured logging via `ILogger<T>`. 
+- **No String Interpolation:** NEVER use string interpolation (`$"{variable}"`) inside logging message templates. Use parameterized templates so log aggregators (like Serilog/Elasticsearch) can index the properties.
+  - *BAD:* `_logger.LogInformation($"User {userId} logged in.");`
+  - *GOOD:* `_logger.LogInformation("User {UserId} logged in.", userId);`
+- **Appropriate Log Levels:**
+  - `Error`: For unhandled exceptions or critical failures that require immediate attention.
+  - `Warning`: For handled exceptions, retries, or unexpected but non-fatal states (e.g., "Rate limit exceeded").
+  - `Information`: For significant business events (e.g., "Order placed", "Entity created").
+  - `Debug`: For detailed tracing information used only during development.
+
+## 4. 📊 Test Organization
+- **Test Projects:** Keep tests in separate projects (e.g., `KanbAI-Core.Tests`, `KanbAI-Core.IntegrationTests`).
+- **Mirror Structure:** Test file structure should mirror the production code structure.
+- **Shared Fixtures:** Use xUnit's `IClassFixture<T>` and `ICollectionFixture<T>` for shared setup.
+
+## 5. 🎯 Assertion Best Practices
+- **Specific Assertions:** Use specific assertions rather than generic ones (e.g., `Should().BeEmpty()` instead of `Should().HaveCount(0)`).
+- **Multiple Assertions:** Group related assertions together, but avoid testing multiple unrelated behaviors in a single test.
+- **Error Messages:** Provide clear failure messages for custom assertions.
+
+## 6. 🔄 Test Maintenance
+- **Keep Tests Fast:** Unit tests should run in milliseconds. Slow tests indicate integration concerns leaking in.
+- **No Test Interdependencies:** Each test should be independent and runnable in any order.
+- **Clean Up:** Always clean up resources (files, database connections) in test teardown.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "additionalDirectories": [
+      "C:\\temp\\KanbAI-Core\\.claude"
+    ]
+  }
+}

--- a/.claude/skills/acceptance-criteria-quality.md
+++ b/.claude/skills/acceptance-criteria-quality.md
@@ -1,0 +1,163 @@
+---
+name: acceptance-criteria-quality
+description: Guidelines for writing high-quality acceptance criteria that are testable, specific, independent, implementation-free, and complete.
+---
+
+# Acceptance Criteria Quality Standards
+
+## When to Use
+
+Use this skill when:
+- Creating a context note as a Product Manager
+- Reviewing acceptance criteria before finalizing a handoff document
+- Evaluating whether AC are sufficient for QA testing
+
+## What Makes Good Acceptance Criteria?
+
+Good acceptance criteria are **TSIIC**:
+- **T**estable
+- **S**pecific
+- **I**ndependent
+- **I**mplementation-free
+- **C**omplete
+
+## The TSIIC Checklist
+
+### 1. Testable
+**Question:** Could a QA engineer write an automated assertion for this criterion?
+
+**BAD:**
+- "The system should be fast"
+- "The UI should be user-friendly"
+- "Error handling should be robust"
+
+**GOOD:**
+- "When a user submits a login form with valid credentials, the system responds within 2 seconds"
+- "When a user enters an invalid email format, the system displays an inline error message 'Invalid email format'"
+- "When the database connection fails, the system returns HTTP 503 with error code 'DB_UNAVAILABLE'"
+
+### 2. Specific
+**Question:** Does it reference a concrete behavior, not a vague quality?
+
+**BAD:**
+- "Users can manage their boards"
+- "The system handles errors gracefully"
+- "Authentication works correctly"
+
+**GOOD:**
+- "Users can create a new board by clicking the 'New Board' button, entering a board name, and clicking 'Create'"
+- "When a user enters a duplicate email during registration, the system returns HTTP 409 with message 'Email already exists'"
+- "When a user submits valid credentials, the system returns a JWT token with a 30-minute expiration"
+
+### 3. Independent
+**Question:** Does it describe a single verifiable outcome, not a compound requirement?
+
+**BAD:**
+- "Users can register, login, and update their profile"
+- "The system validates input and stores it securely in the database"
+
+**GOOD:**
+Split into multiple criteria:
+- "Users can register by providing email, username, and password"
+- "Users can login with their registered credentials"
+- "Users can update their profile name and avatar"
+
+### 4. Implementation-Free
+**Question:** Does it describe *what* the system does, not *how* it does it?
+
+**BAD:**
+- "The system uses BCrypt to hash passwords with a work factor of 12"
+- "The API stores user data in a SQL Server database using Entity Framework Core"
+- "The frontend calls the POST /api/auth/register endpoint"
+
+**GOOD:**
+- "When a user registers, the system stores their password securely (never in plain text)"
+- "When a user registers, the system persists their email, username, and password"
+- "When a user registers successfully, the system responds with their user ID"
+
+### 5. Complete
+**Question:** Are edge cases and failure modes covered?
+
+**Incomplete AC (only happy path):**
+- "Users can register with email and password"
+
+**Complete AC (includes edge cases):**
+- "Users can register with a valid email (format: name@domain.com) and password (minimum 8 characters)"
+- "When a user attempts to register with an email that already exists, the system returns HTTP 409 with message 'Email already registered'"
+- "When a user attempts to register with a password shorter than 8 characters, the system returns HTTP 400 with message 'Password must be at least 8 characters'"
+- "When a user attempts to register with an invalid email format, the system returns HTTP 400 with message 'Invalid email format'"
+- "When a user successfully registers, the system returns HTTP 201 with the new user's ID"
+
+## Examples: Bad vs. Good
+
+### Example 1: User Registration
+
+**❌ BAD:**
+- "Users should be able to sign up"
+
+**✅ GOOD:**
+- "When a user submits the registration form with valid email, username, and password (8+ chars), the system creates an account and returns HTTP 201"
+- "When a user submits a registration form with an existing email, the system returns HTTP 409 with message 'Email already registered'"
+- "When a user submits a registration form with a password less than 8 characters, the system returns HTTP 400 with validation error"
+- "When a user submits a registration form with an invalid email format, the system returns HTTP 400 with validation error"
+
+### Example 2: Board Creation
+
+**❌ BAD:**
+- "Users can create boards with columns"
+
+**✅ GOOD:**
+- "When a logged-in user submits a valid board name (1-100 characters), the system creates a board and returns HTTP 201 with the board ID"
+- "When a user attempts to create a board without authentication, the system returns HTTP 401"
+- "When a user attempts to create a board with an empty name, the system returns HTTP 400 with message 'Board name is required'"
+- "When a user attempts to create a board with a name exceeding 100 characters, the system returns HTTP 400 with message 'Board name must be 100 characters or less'"
+
+### Example 3: Password Hashing
+
+**❌ BAD (implementation details):**
+- "The system uses BCrypt with work factor 12 to hash passwords before storing them in the Users table"
+
+**✅ GOOD (behavior, not implementation):**
+- "When a user registers, the system stores their password securely (hashed, never plain text)"
+- "When a user logs in with correct credentials, the system verifies the password against the stored hash"
+- "When a user logs in with incorrect password, the system returns HTTP 401"
+
+## Red Flags to Avoid
+
+🚩 **Vague adjectives:** "quickly", "efficiently", "securely", "reliably"
+🚩 **Implementation details:** Class names, method names, database tables, algorithms
+🚩 **Technology choices:** "using JWT", "with BCrypt", "via Entity Framework"
+🚩 **Multiple behaviors in one criterion:** "Users can create, update, and delete boards"
+🚩 **Missing edge cases:** Only describing the happy path
+
+## Template for Writing AC
+
+Use this template structure:
+
+```
+**Feature: [Feature Name]**
+
+**Happy Path:**
+- When [user action] with [valid input], the system [expected behavior] and returns [expected response]
+
+**Edge Cases:**
+- When [user action] with [invalid input: case 1], the system returns [error response with message]
+- When [user action] with [invalid input: case 2], the system returns [error response with message]
+
+**Authorization/Security:**
+- When [unauthorized user] attempts [protected action], the system returns HTTP 401/403
+
+**Performance (if applicable):**
+- When [user action] occurs, the system responds within [time constraint]
+```
+
+## Self-Review Checklist
+
+Before finalizing AC, ask yourself:
+
+- [ ] Can I write an automated test for each criterion?
+- [ ] Does each criterion describe ONE verifiable behavior?
+- [ ] Have I avoided mentioning implementation details?
+- [ ] Have I covered edge cases and failure scenarios?
+- [ ] Are the expected responses specific (HTTP codes, error messages)?
+- [ ] Would a developer unfamiliar with the project understand what to build from these AC alone?

--- a/.claude/skills/ef-core-migration.md
+++ b/.claude/skills/ef-core-migration.md
@@ -1,0 +1,155 @@
+---
+name: ef-core-migration
+description: Best practices for EF Core migration generation, design-time context resolution, and post-generation validation. Use when implementing entity changes, DbContext updates, or running dotnet ef migrations.
+---
+
+# EF Core Migration Skill
+
+## When to Use
+
+Read this skill whenever an implementation involves:
+- Creating or modifying entity classes
+- Adding `DbSet<>` properties to `ApplicationDbContext`
+- Creating or modifying `IEntityTypeConfiguration<T>` classes
+- Generating a new EF Core migration via `dotnet ef migrations add`
+
+## 1. Design-Time Context Resolution
+
+EF Core CLI tools (`dotnet ef`) must create a `DbContext` instance at design time. The tool tries two strategies in order:
+
+1. **Application host startup** — Builds the full app via `Program.cs`. This can fail if:
+   - A NuGet package DLL is blocked (e.g., Windows WDAC policy)
+   - Environment-specific secrets or connection strings are missing
+   - The startup pipeline has middleware that fails outside Kestrel
+
+2. **`IDesignTimeDbContextFactory<T>`** — A factory class the CLI falls back to if host startup fails.
+
+### When to Create a Design-Time Factory
+
+Create `Data/DesignTimeDbContextFactory.cs` if ANY of these conditions apply:
+- The application host fails to start during `dotnet ef` (check the error output)
+- The project uses middleware or packages that are unavailable at design time
+- The CI/CD pipeline runs migrations without full application secrets
+
+### Factory Template
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
+namespace KanbAI_Core.Data;
+
+public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<ApplicationDbContext>
+{
+    public ApplicationDbContext CreateDbContext(string[] args)
+    {
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: true)
+            .AddJsonFile("appsettings.Development.json", optional: true)
+            .Build();
+
+        var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
+        optionsBuilder.UseSqlServer(configuration.GetConnectionString("DefaultConnection"));
+
+        return new ApplicationDbContext(optionsBuilder.Options);
+    }
+}
+```
+
+**Key points:**
+- The factory bypasses the entire application startup pipeline
+- It reads connection strings directly from `appsettings*.json`
+- It does NOT register services, middleware, or authentication — only builds the context
+- If the factory already exists in the project, do NOT create a duplicate
+
+## 2. Migration Naming Convention
+
+Use descriptive PascalCase names that reflect the domain change:
+
+| Good | Bad |
+|------|-----|
+| `AddUserEntity` | `Migration1` |
+| `AddBoardAndColumnEntities` | `Update` |
+| `AddUniqueIndexOnUserEmail` | `Fix` |
+| `RemoveObsoleteTaskStatusColumn` | `Changes_April_2026` |
+
+**Rule:** The name should answer "What does this migration do?" without opening the file.
+
+## 3. Migration Generation Command
+
+Always run from the project directory that contains the `DbContext`:
+
+```bash
+dotnet ef migrations add {MigrationName}
+```
+
+If the project uses a separate startup project:
+
+```bash
+dotnet ef migrations add {MigrationName} --startup-project ../StartupProject
+```
+
+## 4. Post-Generation Validation
+
+After generating a migration, **always verify** the migration file before proceeding:
+
+### Column Verification
+
+Compare each column in the generated migration against the tech spec's expected schema table:
+
+| Check | What to Verify |
+|-------|---------------|
+| **Column names** | Do they match entity property names (PascalCase)? |
+| **SQL types** | Do they match the expected types from the tech spec (e.g., `nvarchar(150)`, `uniqueidentifier`, `int`)? |
+| **Nullability** | Are required columns marked `nullable: false`? |
+| **Default values** | Are defaults present where the spec requires them (e.g., enum defaults)? |
+| **Max lengths** | Do `HasMaxLength()` constraints produce the expected `nvarchar(N)` sizes? |
+
+### Constraint Verification
+
+| Check | What to Verify |
+|-------|---------------|
+| **Primary key** | Is the PK correctly defined (usually on `Id`)? |
+| **Unique indexes** | Are unique constraints created with the expected index name (e.g., `IX_Users_Email`)? |
+| **Foreign keys** | Are FK relationships and cascade behaviors correct? |
+| **Table name** | Does the table name match expectations (EF Core uses the `DbSet` property name by default)? |
+
+### Down Migration
+
+Verify the `Down` method correctly reverses the `Up` method (drops the table, removes indexes, etc.).
+
+## 5. Common Pitfalls
+
+| Pitfall | Symptom | Solution |
+|---------|---------|----------|
+| WDAC blocks a DLL at design time | `FileLoadException: An Application Control policy has blocked this file` | Create a `DesignTimeDbContextFactory` |
+| Missing connection string | `Unable to resolve service for DbContextOptions` | Ensure `appsettings.Development.json` has a valid `ConnectionStrings:DefaultConnection` |
+| Snapshot conflict | Migration generates unexpected changes | Delete the bad migration with `dotnet ef migrations remove` and regenerate |
+| Empty migration | `Up()` and `Down()` methods are empty | The model change was not detected — verify the entity is registered via `DbSet<>` and configurations are applied in `OnModelCreating` |
+| `OnModelCreating` not called | Configurations are ignored | Ensure `modelBuilder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly)` is called in the override |
+
+## 6. Migration in Existing Projects
+
+When a project already has migrations, check the `ApplicationDbContextModelSnapshot.cs` after generation. It should include the new entity's model definition. If the snapshot looks incorrect, the migration will produce wrong SQL — remove and regenerate.
+
+## 7. Applying Migrations
+
+To apply migrations to the database:
+
+```bash
+dotnet ef database update
+```
+
+To apply up to a specific migration:
+
+```bash
+dotnet ef database update {MigrationName}
+```
+
+To rollback to a previous state:
+
+```bash
+dotnet ef database update {PreviousMigrationName}
+```

--- a/.claude/skills/pre-implementation-checklist.md
+++ b/.claude/skills/pre-implementation-checklist.md
@@ -1,0 +1,123 @@
+---
+name: pre-implementation-checklist
+description: Systematic verification checklist to run before writing any code. Use when beginning implementation of a tech spec to catch missing directories, packages, naming conflicts, and spec ambiguities early.
+---
+
+# Pre-Implementation Checklist
+
+## When to Use
+
+Run this checklist after reading a `_tech_spec.md` and before creating or modifying any `.cs` files. The goal is to surface blockers early — a missing folder or package discovered mid-implementation wastes context and forces backtracking.
+
+## The Checklist
+
+### 1. Directory Readiness
+
+For every file path listed in the tech spec's "Implementation Steps" section:
+
+| Check | Action if Failed |
+|-------|------------------|
+| Does the **target directory** exist? | Create it before writing any files. |
+| Does the target directory follow the project's established folder conventions? | Verify against existing structure (e.g., `Models/Entities/`, `Data/Configurations/`, `Models/Enums/`). |
+
+**How to check:**
+```bash
+# List existing directories
+ls -la Models/
+ls -la Data/
+ls -la DTOs/
+
+# Create missing directories
+mkdir -p Models/Enums
+mkdir -p Data/Configurations
+```
+
+### 2. Package Dependencies
+
+For every NuGet package the tech spec assumes is available:
+
+| Check | Action if Failed |
+|-------|------------------|
+| Is the package listed in the `.csproj` file? | Add it via `dotnet add package {Name}` before implementation. |
+| Is the installed version compatible with the target framework? | Check the `.csproj` `<TargetFramework>` and the package's supported frameworks. |
+
+**How to check:**
+```bash
+# View installed packages
+dotnet list package
+
+# Add missing package
+dotnet add package Microsoft.EntityFrameworkCore
+dotnet add package FluentValidation
+```
+
+### 3. Naming Conflict Scan
+
+For every new class, enum, record, or interface the tech spec defines:
+
+| Check | Action if Failed |
+|-------|------------------|
+| Does a type with the **same name** already exist anywhere in the project? | Search the codebase (e.g., `class {Name}`, `enum {Name}`, `record {Name}`). If a conflict exists, stop and ask the user to clarify with the Staff Engineer. |
+| Does the new **namespace** match the project's `RootNamespace` and folder path convention? | Verify against existing files in the same directory. |
+
+**How to check:**
+```bash
+# Search for existing type names
+grep -r "class UserEntity" --include="*.cs"
+grep -r "enum UserStatus" --include="*.cs"
+grep -r "record UserDto" --include="*.cs"
+```
+
+Or use the Grep tool:
+- Pattern: `class {TypeName}` or `enum {TypeName}` or `record {TypeName}`
+- Output mode: `files_with_matches`
+
+### 4. Tech Spec Completeness
+
+For every file the tech spec asks you to create or modify:
+
+| Check | Action if Failed |
+|-------|------------------|
+| Does the spec provide the **exact code** or at minimum the full type signature? | If only a vague description is given, ask the user to clarify with the Staff Engineer. Do not guess. |
+| Are **all referenced types** (base classes, enums, interfaces) either already in the codebase or defined elsewhere in the spec? | If a type is referenced but not defined, stop and ask. |
+| For modified files: does the spec describe **where** the change goes (property position, method location)? | If ambiguous, read the target file first to determine the correct insertion point. |
+
+### 5. EF Core Readiness (if applicable)
+
+Only run these checks when the tech spec includes entity or migration work:
+
+| Check | Action if Failed |
+|-------|------------------|
+| Does `ApplicationDbContext` already have an `OnModelCreating` override? | If not, the spec should include adding one. |
+| Can `dotnet ef` resolve the DbContext at design time? | If the project lacks a `DesignTimeDbContextFactory` and the app host cannot start (e.g., WDAC policy, missing secrets), create one. See the `ef-core-migration` skill. |
+| Are all entity configurations using `IEntityTypeConfiguration<T>` (not inline in `OnModelCreating`)? | Follow existing patterns in `Data/Configurations/`. |
+
+**How to check:**
+```bash
+# Test EF Core design-time resolution
+dotnet ef migrations list
+
+# If it fails, you may need a DesignTimeDbContextFactory
+```
+
+### 6. Build Baseline
+
+Before making any changes, verify the solution builds successfully:
+
+```bash
+dotnet build
+```
+
+If the build fails before you start, document the pre-existing issues so you can distinguish them from issues you introduce.
+
+## Output
+
+After completing the checklist, you should have:
+- ✅ All required directories created
+- ✅ All required packages installed
+- ✅ Confidence that no naming conflicts exist
+- ✅ A clear understanding of every file to create or modify
+- ✅ EF Core tooling confirmed working (if applicable)
+- ✅ Baseline build status documented
+
+Only then proceed to implementation.


### PR DESCRIPTION
Migrate Cursor IDE rules to `.claude/` directory, adapting them for Claude Code's agent system and toolset. This setup defines specialized roles (PM, Staff Engineer, Developer, QA), global .NET coding standards, and reusable skills for EF Core migrations and testing.