### PR TITLE
46 implement kanban task creation API (#46)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,11 @@
       "Bash(gh issue *)",
       "Bash(dotnet build *)",
       "Bash(dotnet test *)",
-      "Read(//c/c/temp/KanbAI-Core/KanbAI-Core/**)"
+      "Read(//c/c/temp/KanbAI-Core/KanbAI-Core/**)",
+      "Bash(awk '{print $NF}')",
+      "Bash(grep \"\\\\.cs$\")",
+      "Bash(xargs -I {} find {} -type f -name \"*.cs\")",
+      "Bash(xargs grep *)"
     ],
     "additionalDirectories": [
       "C:\\temp\\KanbAI-Core\\.claude"

--- a/KanbAI-Core/KanbAI-Core.Tests/Controllers/TaskControllerTests.cs
+++ b/KanbAI-Core/KanbAI-Core.Tests/Controllers/TaskControllerTests.cs
@@ -1,0 +1,329 @@
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using FluentAssertions;
+using KanbAI_Core.Controllers;
+using KanbAI_Core.DTOs;
+using KanbAI_Core.Services.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace KanbAI_Core.Tests.Controllers;
+
+public class TaskControllerTests
+{
+    private readonly Mock<ITaskService> _taskServiceMock;
+    private readonly Mock<ILogger<TaskController>> _loggerMock;
+    private readonly TaskController _controller;
+
+    public TaskControllerTests()
+    {
+        _taskServiceMock = new Mock<ITaskService>();
+        _loggerMock = new Mock<ILogger<TaskController>>();
+        _controller = new TaskController(_taskServiceMock.Object, _loggerMock.Object);
+    }
+
+    #region CreateTask HTTP Mapping Tests
+
+    [Fact]
+    public async Task CreateTask_ServiceReturnsSuccess_Returns201CreatedWithLocationHeader()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var columnId = Guid.NewGuid();
+        SetupUserClaims(userId);
+
+        var dto = new CreateTaskDto { Title = "New Task" };
+        var responseDto = new TaskResponseDto
+        {
+            Id = Guid.NewGuid().ToString(),
+            Title = "New Task",
+            Content = null,
+            TaskOrder = 0,
+            ColumnId = columnId.ToString(),
+            AssignedId = null,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        _taskServiceMock
+            .Setup(s => s.CreateTaskAsync(columnId, dto, userId))
+            .ReturnsAsync((responseDto, CreateTaskResult.Success));
+
+        // Act
+        var result = await _controller.CreateTask(columnId, dto);
+
+        // Assert
+        var createdResult = result.Should().BeOfType<CreatedAtActionResult>().Subject;
+        createdResult.StatusCode.Should().Be(201);
+        createdResult.ActionName.Should().Be(nameof(TaskController.CreateTask));
+        createdResult.RouteValues!["columnId"].Should().Be(responseDto.ColumnId);
+
+        var apiResponse = createdResult.Value.Should().BeOfType<ApiResponse<TaskResponseDto>>().Subject;
+        apiResponse.Success.Should().BeTrue();
+        apiResponse.Message.Should().Be("Task created successfully.");
+        apiResponse.Data.Should().BeEquivalentTo(responseDto);
+    }
+
+    [Fact]
+    public async Task CreateTask_ServiceReturnsColumnNotFound_Returns404()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var columnId = Guid.NewGuid();
+        SetupUserClaims(userId);
+
+        var dto = new CreateTaskDto { Title = "Task" };
+
+        _taskServiceMock
+            .Setup(s => s.CreateTaskAsync(columnId, dto, userId))
+            .ReturnsAsync((null, CreateTaskResult.ColumnNotFound));
+
+        // Act
+        var result = await _controller.CreateTask(columnId, dto);
+
+        // Assert
+        var notFound = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFound.StatusCode.Should().Be(404);
+
+        var apiResponse = notFound.Value.Should().BeOfType<ApiResponse>().Subject;
+        apiResponse.Success.Should().BeFalse();
+        apiResponse.Message.Should().Be("Column not found.");
+    }
+
+    [Fact]
+    public async Task CreateTask_ServiceReturnsUserNotProjectMember_Returns403()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var columnId = Guid.NewGuid();
+        SetupUserClaims(userId);
+
+        var dto = new CreateTaskDto { Title = "Task" };
+
+        _taskServiceMock
+            .Setup(s => s.CreateTaskAsync(columnId, dto, userId))
+            .ReturnsAsync((null, CreateTaskResult.UserNotProjectMember));
+
+        // Act
+        var result = await _controller.CreateTask(columnId, dto);
+
+        // Assert
+        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+
+        var apiResponse = objectResult.Value.Should().BeOfType<ApiResponse>().Subject;
+        apiResponse.Success.Should().BeFalse();
+        apiResponse.Message.Should().Be("You are not a member of this project.");
+    }
+
+    [Fact]
+    public async Task CreateTask_ServiceReturnsAssignedUserNotFound_Returns400()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var columnId = Guid.NewGuid();
+        SetupUserClaims(userId);
+
+        var dto = new CreateTaskDto { Title = "Task", AssignedId = Guid.NewGuid() };
+
+        _taskServiceMock
+            .Setup(s => s.CreateTaskAsync(columnId, dto, userId))
+            .ReturnsAsync((null, CreateTaskResult.AssignedUserNotFound));
+
+        // Act
+        var result = await _controller.CreateTask(columnId, dto);
+
+        // Assert
+        var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badRequest.StatusCode.Should().Be(400);
+
+        var apiResponse = badRequest.Value.Should().BeOfType<ApiResponse>().Subject;
+        apiResponse.Success.Should().BeFalse();
+        apiResponse.Message.Should().Be("Assigned user not found.");
+    }
+
+    [Fact]
+    public async Task CreateTask_ServiceReturnsAssignedUserNotProjectMember_Returns400()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var columnId = Guid.NewGuid();
+        SetupUserClaims(userId);
+
+        var dto = new CreateTaskDto { Title = "Task", AssignedId = Guid.NewGuid() };
+
+        _taskServiceMock
+            .Setup(s => s.CreateTaskAsync(columnId, dto, userId))
+            .ReturnsAsync((null, CreateTaskResult.AssignedUserNotProjectMember));
+
+        // Act
+        var result = await _controller.CreateTask(columnId, dto);
+
+        // Assert
+        var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badRequest.StatusCode.Should().Be(400);
+
+        var apiResponse = badRequest.Value.Should().BeOfType<ApiResponse>().Subject;
+        apiResponse.Success.Should().BeFalse();
+        apiResponse.Message.Should().Be("Assigned user is not a member of this project.");
+    }
+
+    [Fact]
+    public async Task CreateTask_ServiceReturnsInvalidTitle_Returns400()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var columnId = Guid.NewGuid();
+        SetupUserClaims(userId);
+
+        var dto = new CreateTaskDto { Title = "   " };
+
+        _taskServiceMock
+            .Setup(s => s.CreateTaskAsync(columnId, dto, userId))
+            .ReturnsAsync((null, CreateTaskResult.InvalidTitle));
+
+        // Act
+        var result = await _controller.CreateTask(columnId, dto);
+
+        // Assert
+        var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badRequest.StatusCode.Should().Be(400);
+
+        var apiResponse = badRequest.Value.Should().BeOfType<ApiResponse>().Subject;
+        apiResponse.Success.Should().BeFalse();
+        apiResponse.Message.Should().Be("Task title is required.");
+    }
+
+    #endregion
+
+    #region Claims Extraction Tests
+
+    [Fact]
+    public async Task CreateTask_MissingNameIdentifierClaim_ThrowsUnauthorizedAccessException()
+    {
+        // Arrange
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity())
+            }
+        };
+
+        var columnId = Guid.NewGuid();
+        var dto = new CreateTaskDto { Title = "Task" };
+
+        // Act
+        Func<Task> act = async () => await _controller.CreateTask(columnId, dto);
+
+        // Assert
+        await act.Should().ThrowAsync<UnauthorizedAccessException>()
+            .WithMessage("Invalid or missing user ID in token.");
+    }
+
+    [Fact]
+    public async Task CreateTask_InvalidNameIdentifierClaim_ThrowsUnauthorizedAccessException()
+    {
+        // Arrange
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, "not-a-guid")
+        };
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"))
+            }
+        };
+
+        var columnId = Guid.NewGuid();
+        var dto = new CreateTaskDto { Title = "Task" };
+
+        // Act
+        Func<Task> act = async () => await _controller.CreateTask(columnId, dto);
+
+        // Assert
+        await act.Should().ThrowAsync<UnauthorizedAccessException>()
+            .WithMessage("Invalid or missing user ID in token.");
+    }
+
+    #endregion
+
+    #region DTO Validation Tests
+
+    [Fact]
+    public void CreateTaskDto_MissingTitle_FailsDataAnnotationsValidation()
+    {
+        // Arrange
+        var dto = new CreateTaskDto { Title = "" };
+
+        // Act
+        var validationContext = new ValidationContext(dto);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(dto, validationContext, validationResults, true);
+
+        // Assert
+        isValid.Should().BeFalse();
+        validationResults.Should().Contain(vr => vr.MemberNames.Contains("Title"));
+    }
+
+    [Fact]
+    public void CreateTaskDto_TitleExceeds200Chars_FailsDataAnnotationsValidation()
+    {
+        // Arrange
+        var dto = new CreateTaskDto { Title = new string('A', 201) };
+
+        // Act
+        var validationContext = new ValidationContext(dto);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(dto, validationContext, validationResults, true);
+
+        // Assert
+        isValid.Should().BeFalse();
+        validationResults.Should().Contain(vr => vr.MemberNames.Contains("Title"));
+    }
+
+    [Fact]
+    public void CreateTaskDto_TitleAtBoundary_PassesDataAnnotationsValidation()
+    {
+        // Arrange
+        var dto = new CreateTaskDto { Title = new string('A', 200) };
+
+        // Act
+        var validationContext = new ValidationContext(dto);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(dto, validationContext, validationResults, true);
+
+        // Assert
+        isValid.Should().BeTrue();
+        validationResults.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private void SetupUserClaims(Guid userId)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId.ToString())
+        };
+
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var claimsPrincipal = new ClaimsPrincipal(identity);
+
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = claimsPrincipal
+            }
+        };
+    }
+
+    #endregion
+}

--- a/KanbAI-Core/KanbAI-Core.Tests/Integration/TaskApiIntegrationTests.cs
+++ b/KanbAI-Core/KanbAI-Core.Tests/Integration/TaskApiIntegrationTests.cs
@@ -1,0 +1,184 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using FluentAssertions;
+using KanbAI_Core.DTOs;
+using KanbAI_Core.Tests.Fixtures;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace KanbAI_Core.Tests.Integration;
+
+/// <summary>
+/// Integration tests for Task API endpoints.
+/// These tests focus on HTTP-level concerns (status codes, validation, authentication).
+/// Database-level concerns are covered by unit tests using in-memory EF Core.
+/// </summary>
+public class TaskApiIntegrationTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly CustomWebApplicationFactory _factory;
+
+    public TaskApiIntegrationTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    #region Security Tests
+
+    [Fact]
+    public async Task PostTask_Unauthenticated_Returns401()
+    {
+        // Arrange
+        var client = CreateUnauthenticatedClient();
+        var columnId = Guid.NewGuid();
+        var dto = new CreateTaskDto { Title = "Task" };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/task/column/{columnId}", dto);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    #endregion
+
+    #region Validation Tests
+
+    [Fact]
+    public async Task PostTask_MissingTitleInBody_Returns400()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var client = CreateAuthenticatedClient(userId);
+        var columnId = Guid.NewGuid();
+
+        var invalidBody = new { content = "missing title" };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/task/column/{columnId}", invalidBody);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task PostTask_TitleTooLong_Returns400()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var client = CreateAuthenticatedClient(userId);
+        var columnId = Guid.NewGuid();
+
+        var dto = new CreateTaskDto { Title = new string('A', 201) };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/task/column/{columnId}", dto);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task PostTask_EmptyTitleInBody_Returns400()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var client = CreateAuthenticatedClient(userId);
+        var columnId = Guid.NewGuid();
+
+        var body = new { title = "" };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/task/column/{columnId}", body);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    #endregion
+
+    #region Test Infrastructure
+
+    private HttpClient CreateAuthenticatedClient(Guid userId)
+    {
+        return _factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureTestServices(services =>
+            {
+                var authConfigs = services
+                    .Where(d => d.ServiceType == typeof(IConfigureOptions<AuthenticationOptions>))
+                    .ToList();
+                foreach (var descriptor in authConfigs)
+                    services.Remove(descriptor);
+
+                services.AddAuthentication("Test")
+                    .AddScheme<TestAuthSchemeOptions, TestAuthHandler>(
+                        "Test",
+                        options => options.UserId = userId);
+
+                services.AddAuthorization(options => options.FallbackPolicy = null);
+            });
+        }).CreateClient();
+    }
+
+    private HttpClient CreateUnauthenticatedClient()
+    {
+        return _factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureTestServices(services =>
+            {
+                var authConfigs = services
+                    .Where(d => d.ServiceType == typeof(IConfigureOptions<AuthenticationOptions>))
+                    .ToList();
+                foreach (var descriptor in authConfigs)
+                    services.Remove(descriptor);
+
+                services.AddAuthentication("Test")
+                    .AddScheme<TestAuthSchemeOptions, TestAuthHandler>("Test", _ => { });
+            });
+        }).CreateClient();
+    }
+
+    private sealed class TestAuthSchemeOptions : AuthenticationSchemeOptions
+    {
+        public Guid? UserId { get; set; }
+    }
+
+    private sealed class TestAuthHandler : AuthenticationHandler<TestAuthSchemeOptions>
+    {
+        public TestAuthHandler(
+            IOptionsMonitor<TestAuthSchemeOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (Options.UserId.HasValue)
+            {
+                var claims = new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, Options.UserId.Value.ToString())
+                };
+                var identity = new ClaimsIdentity(claims, "Test");
+                var principal = new ClaimsPrincipal(identity);
+                var ticket = new AuthenticationTicket(principal, "Test");
+
+                return Task.FromResult(AuthenticateResult.Success(ticket));
+            }
+
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+    }
+
+    #endregion
+}

--- a/KanbAI-Core/KanbAI-Core.Tests/Services/Tasks/TaskServiceTests.cs
+++ b/KanbAI-Core/KanbAI-Core.Tests/Services/Tasks/TaskServiceTests.cs
@@ -1,0 +1,373 @@
+using FluentAssertions;
+using KanbAI_Core.Data;
+using KanbAI_Core.DTOs;
+using KanbAI_Core.Models.Entities;
+using KanbAI_Core.Models.Enums;
+using KanbAI_Core.Services.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace KanbAI_Core.Tests.Services.Tasks;
+
+public class TaskServiceTests
+{
+    private readonly Mock<ILogger<TaskService>> _loggerMock;
+
+    public TaskServiceTests()
+    {
+        _loggerMock = new Mock<ILogger<TaskService>>();
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_UserIsMember_EmptyColumn_CreatesTaskWithOrderZero()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId) = await SeedProjectWithColumnAsync(context, userId);
+
+        var dto = new CreateTaskDto { Title = "First Task" };
+
+        // Act
+        var (data, result) = await service.CreateTaskAsync(columnId, dto, userId);
+
+        // Assert
+        result.Should().Be(CreateTaskResult.Success);
+        data.Should().NotBeNull();
+        data!.TaskOrder.Should().Be(0);
+        data.Title.Should().Be("First Task");
+        data.ColumnId.Should().Be(columnId.ToString());
+        data.AssignedId.Should().BeNull();
+
+        var persisted = await context.KanbanTasks.SingleAsync();
+        persisted.TaskOrder.Should().Be(0);
+        persisted.ColumnId.Should().Be(columnId);
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_UserIsMember_NonEmptyColumn_TaskOrderIsMaxPlusOne()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId) = await SeedProjectWithColumnAsync(context, userId);
+
+        context.KanbanTasks.AddRange(
+            new KanbanTask { Title = "A", TaskOrder = 0, ColumnId = columnId },
+            new KanbanTask { Title = "B", TaskOrder = 1, ColumnId = columnId },
+            new KanbanTask { Title = "C", TaskOrder = 2, ColumnId = columnId });
+        await context.SaveChangesAsync();
+
+        var dto = new CreateTaskDto { Title = "Next" };
+
+        // Act
+        var (data, result) = await service.CreateTaskAsync(columnId, dto, userId);
+
+        // Assert
+        result.Should().Be(CreateTaskResult.Success);
+        data.Should().NotBeNull();
+        data!.TaskOrder.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_MultipleSequentialCreations_AssignsDistinctOrders()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId) = await SeedProjectWithColumnAsync(context, userId);
+
+        // Act
+        var orders = new List<int>();
+        for (var i = 0; i < 4; i++)
+        {
+            var (data, result) = await service.CreateTaskAsync(
+                columnId,
+                new CreateTaskDto { Title = $"Task {i}" },
+                userId);
+
+            result.Should().Be(CreateTaskResult.Success);
+            orders.Add(data!.TaskOrder);
+        }
+
+        // Assert
+        orders.Should().BeEquivalentTo(new[] { 0, 1, 2, 3 }, opts => opts.WithStrictOrdering());
+        (await context.KanbanTasks.CountAsync()).Should().Be(4);
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_UserIsMember_NoAssignment_PersistsWithNullAssignedId()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId) = await SeedProjectWithColumnAsync(context, userId);
+
+        var dto = new CreateTaskDto { Title = "Unassigned", Content = null };
+
+        // Act
+        var (data, result) = await service.CreateTaskAsync(columnId, dto, userId);
+
+        // Assert
+        result.Should().Be(CreateTaskResult.Success);
+        data!.AssignedId.Should().BeNull();
+
+        var persisted = await context.KanbanTasks.SingleAsync();
+        persisted.AssignedId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_UserIsMember_ValidAssignment_PersistsWithAssignedId()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId) = await SeedProjectWithColumnAsync(context, userId);
+
+        var assigneeId = Guid.NewGuid();
+        context.Users.Add(new User
+        {
+            Id = assigneeId,
+            Name = "Alice",
+            Email = "alice@example.com",
+            PasswordHash = "hash"
+        });
+        context.ProjectMembers.Add(new ProjectMember
+        {
+            ProjectId = projectId,
+            UserId = assigneeId,
+            Role = ProjectRole.Member
+        });
+        await context.SaveChangesAsync();
+
+        var dto = new CreateTaskDto { Title = "Assigned", AssignedId = assigneeId };
+
+        // Act
+        var (data, result) = await service.CreateTaskAsync(columnId, dto, userId);
+
+        // Assert
+        result.Should().Be(CreateTaskResult.Success);
+        data!.AssignedId.Should().Be(assigneeId.ToString());
+
+        var persisted = await context.KanbanTasks.SingleAsync();
+        persisted.AssignedId.Should().Be(assigneeId);
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_ColumnDoesNotExist_ReturnsColumnNotFound()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var nonExistentColumnId = Guid.NewGuid();
+
+        var dto = new CreateTaskDto { Title = "Ghost" };
+
+        // Act
+        var (data, result) = await service.CreateTaskAsync(nonExistentColumnId, dto, userId);
+
+        // Assert
+        result.Should().Be(CreateTaskResult.ColumnNotFound);
+        data.Should().BeNull();
+        (await context.KanbanTasks.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_UserNotProjectMember_ReturnsUserNotProjectMember()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var memberId = Guid.NewGuid();
+        var outsiderId = Guid.NewGuid();
+        var (projectId, columnId) = await SeedProjectWithColumnAsync(context, memberId);
+
+        var dto = new CreateTaskDto { Title = "Should be forbidden" };
+
+        // Act
+        var (data, result) = await service.CreateTaskAsync(columnId, dto, outsiderId);
+
+        // Assert
+        result.Should().Be(CreateTaskResult.UserNotProjectMember);
+        data.Should().BeNull();
+        (await context.KanbanTasks.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_AssignedUserDoesNotExist_ReturnsAssignedUserNotFound()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId) = await SeedProjectWithColumnAsync(context, userId);
+
+        var dto = new CreateTaskDto
+        {
+            Title = "Bogus assignment",
+            AssignedId = Guid.NewGuid()
+        };
+
+        // Act
+        var (data, result) = await service.CreateTaskAsync(columnId, dto, userId);
+
+        // Assert
+        result.Should().Be(CreateTaskResult.AssignedUserNotFound);
+        data.Should().BeNull();
+        (await context.KanbanTasks.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_AssignedUserIsNotProjectMember_ReturnsAssignedUserNotProjectMember()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId) = await SeedProjectWithColumnAsync(context, userId);
+
+        var outsiderUserId = Guid.NewGuid();
+        context.Users.Add(new User
+        {
+            Id = outsiderUserId,
+            Name = "Outsider",
+            Email = "out@example.com",
+            PasswordHash = "hash"
+        });
+        await context.SaveChangesAsync();
+
+        var dto = new CreateTaskDto
+        {
+            Title = "Wrong project assignment",
+            AssignedId = outsiderUserId
+        };
+
+        // Act
+        var (data, result) = await service.CreateTaskAsync(columnId, dto, userId);
+
+        // Assert
+        result.Should().Be(CreateTaskResult.AssignedUserNotProjectMember);
+        data.Should().BeNull();
+        (await context.KanbanTasks.CountAsync()).Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    public async Task CreateTaskAsync_WhitespaceTitle_ReturnsInvalidTitle(string title)
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId) = await SeedProjectWithColumnAsync(context, userId);
+
+        var dto = new CreateTaskDto { Title = title };
+
+        // Act
+        var (data, result) = await service.CreateTaskAsync(columnId, dto, userId);
+
+        // Assert
+        result.Should().Be(CreateTaskResult.InvalidTitle);
+        data.Should().BeNull();
+        (await context.KanbanTasks.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_EmptyContent_PersistsWithNullContent()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId) = await SeedProjectWithColumnAsync(context, userId);
+
+        var dto = new CreateTaskDto { Title = "No description", Content = null };
+
+        // Act
+        var (data, result) = await service.CreateTaskAsync(columnId, dto, userId);
+
+        // Assert
+        result.Should().Be(CreateTaskResult.Success);
+        data!.Content.Should().BeNull();
+
+        var persisted = await context.KanbanTasks.SingleAsync();
+        persisted.Content.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_FailureResultPath_DoesNotPersistEntity()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId) = await SeedProjectWithColumnAsync(context, userId);
+
+        // Trigger all four non-Success paths and verify none create a task.
+        var outsiderId = Guid.NewGuid();
+
+        // Act
+        await service.CreateTaskAsync(Guid.NewGuid(), new CreateTaskDto { Title = "a" }, userId);
+        await service.CreateTaskAsync(columnId, new CreateTaskDto { Title = "b" }, outsiderId);
+        await service.CreateTaskAsync(columnId, new CreateTaskDto { Title = "c", AssignedId = Guid.NewGuid() }, userId);
+        await service.CreateTaskAsync(columnId, new CreateTaskDto { Title = "   " }, userId);
+
+        // Assert
+        (await context.KanbanTasks.CountAsync()).Should().Be(0);
+    }
+
+    private static ApplicationDbContext CreateInMemoryContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+
+    private static async Task<(Guid projectId, Guid columnId)> SeedProjectWithColumnAsync(
+        ApplicationDbContext context,
+        Guid memberUserId)
+    {
+        var projectId = Guid.NewGuid();
+        var project = new Project { Id = projectId, Name = "Test Project" };
+        context.Projects.Add(project);
+
+        context.Users.Add(new User
+        {
+            Id = memberUserId,
+            Name = "Member",
+            Email = $"{memberUserId}@example.com",
+            PasswordHash = "hash"
+        });
+
+        context.ProjectMembers.Add(new ProjectMember
+        {
+            ProjectId = projectId,
+            UserId = memberUserId,
+            Role = ProjectRole.Owner
+        });
+
+        var column = new BoardColumn
+        {
+            Id = Guid.NewGuid(),
+            Name = "To Do",
+            ColumnOrder = 0,
+            ProjectId = projectId
+        };
+        context.BoardColumns.Add(column);
+
+        await context.SaveChangesAsync();
+
+        return (projectId, column.Id);
+    }
+}

--- a/KanbAI-Core/KanbAI-Core/Controllers/TaskController.cs
+++ b/KanbAI-Core/KanbAI-Core/Controllers/TaskController.cs
@@ -1,0 +1,65 @@
+namespace KanbAI_Core.Controllers;
+
+using KanbAI_Core.DTOs;
+using KanbAI_Core.Services.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public sealed class TaskController : ControllerBase
+{
+    private readonly ITaskService _taskService;
+    private readonly ILogger<TaskController> _logger;
+
+    public TaskController(ITaskService taskService, ILogger<TaskController> logger)
+    {
+        _taskService = taskService;
+        _logger = logger;
+    }
+
+    [HttpPost("column/{columnId}")]
+    public async Task<IActionResult> CreateTask(Guid columnId, [FromBody] CreateTaskDto dto)
+    {
+        var userId = GetCurrentUserId();
+
+        var (data, result) = await _taskService.CreateTaskAsync(columnId, dto, userId);
+
+        return result switch
+        {
+            CreateTaskResult.Success =>
+                CreatedAtAction(
+                    nameof(CreateTask),
+                    new { columnId = data!.ColumnId },
+                    ApiResponse<TaskResponseDto>.Ok(data, "Task created successfully.")),
+            CreateTaskResult.ColumnNotFound =>
+                NotFound(ApiResponse.Fail("Column not found.")),
+            CreateTaskResult.UserNotProjectMember =>
+                StatusCode(StatusCodes.Status403Forbidden,
+                    ApiResponse.Fail("You are not a member of this project.")),
+            CreateTaskResult.InvalidTitle =>
+                BadRequest(ApiResponse.Fail("Task title is required.")),
+            CreateTaskResult.AssignedUserNotFound =>
+                BadRequest(ApiResponse.Fail("Assigned user not found.")),
+            CreateTaskResult.AssignedUserNotProjectMember =>
+                BadRequest(ApiResponse.Fail("Assigned user is not a member of this project.")),
+            _ => StatusCode(StatusCodes.Status500InternalServerError,
+                     ApiResponse.Fail("Unexpected error."))
+        };
+    }
+
+    private Guid GetCurrentUserId()
+    {
+        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+        if (string.IsNullOrEmpty(userIdClaim) || !Guid.TryParse(userIdClaim, out var userId))
+        {
+            _logger.LogError("Invalid or missing NameIdentifier claim in JWT token");
+            throw new UnauthorizedAccessException("Invalid or missing user ID in token.");
+        }
+
+        return userId;
+    }
+}

--- a/KanbAI-Core/KanbAI-Core/DTOs/CreateTaskDto.cs
+++ b/KanbAI-Core/KanbAI-Core/DTOs/CreateTaskDto.cs
@@ -1,0 +1,14 @@
+namespace KanbAI_Core.DTOs;
+
+using System.ComponentModel.DataAnnotations;
+
+public record CreateTaskDto
+{
+    [Required(ErrorMessage = "Task title is required.")]
+    [MaxLength(200, ErrorMessage = "Task title cannot exceed 200 characters.")]
+    public required string Title { get; init; }
+
+    public string? Content { get; init; }
+
+    public Guid? AssignedId { get; init; }
+}

--- a/KanbAI-Core/KanbAI-Core/DTOs/TaskResponseDto.cs
+++ b/KanbAI-Core/KanbAI-Core/DTOs/TaskResponseDto.cs
@@ -1,0 +1,13 @@
+namespace KanbAI_Core.DTOs;
+
+public record TaskResponseDto
+{
+    public required string Id { get; init; }
+    public required string Title { get; init; }
+    public string? Content { get; init; }
+    public required int TaskOrder { get; init; }
+    public required string ColumnId { get; init; }
+    public string? AssignedId { get; init; }
+    public required DateTimeOffset CreatedAt { get; init; }
+    public required DateTimeOffset UpdatedAt { get; init; }
+}

--- a/KanbAI-Core/KanbAI-Core/Program.cs
+++ b/KanbAI-Core/KanbAI-Core/Program.cs
@@ -4,6 +4,7 @@ using KanbAI_Core.Models.Entities;
 using KanbAI_Core.Services.Auth;
 using KanbAI_Core.Services.Columns;
 using KanbAI_Core.Services.Projects;
+using KanbAI_Core.Services.Tasks;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 
@@ -16,6 +17,7 @@ builder.Services.AddSingleton<IPasswordHasher, BCryptPasswordHasher>();
 builder.Services.AddTransient<ITokenService, TokenService>();
 builder.Services.AddScoped<IProjectService, ProjectService>();
 builder.Services.AddScoped<IColumnService, ColumnService>();
+builder.Services.AddScoped<ITaskService, TaskService>();
 
 builder.Services
     .AddAuthentication(options =>

--- a/KanbAI-Core/KanbAI-Core/Services/Tasks/CreateTaskResult.cs
+++ b/KanbAI-Core/KanbAI-Core/Services/Tasks/CreateTaskResult.cs
@@ -1,0 +1,11 @@
+namespace KanbAI_Core.Services.Tasks;
+
+public enum CreateTaskResult
+{
+    Success,
+    ColumnNotFound,
+    UserNotProjectMember,
+    AssignedUserNotFound,
+    AssignedUserNotProjectMember,
+    InvalidTitle
+}

--- a/KanbAI-Core/KanbAI-Core/Services/Tasks/ITaskService.cs
+++ b/KanbAI-Core/KanbAI-Core/Services/Tasks/ITaskService.cs
@@ -1,0 +1,21 @@
+namespace KanbAI_Core.Services.Tasks;
+
+using KanbAI_Core.DTOs;
+
+public interface ITaskService
+{
+    /// <summary>
+    /// Creates a new task in the specified column.
+    /// Authorization: the caller must be a member of the project that owns the column.
+    /// If <paramref name="dto"/>.AssignedId is provided, it must reference a user who is a member of the same project.
+    /// The new task's TaskOrder is automatically set to (max existing TaskOrder in column) + 1, or 0 if the column is empty.
+    /// </summary>
+    /// <param name="columnId">The target column ID.</param>
+    /// <param name="dto">Task creation data.</param>
+    /// <param name="userId">The authenticated user's ID (from JWT claims).</param>
+    /// <returns>A tuple containing the created task (on success) and a <see cref="CreateTaskResult"/> discriminator.</returns>
+    Task<(TaskResponseDto? data, CreateTaskResult result)> CreateTaskAsync(
+        Guid columnId,
+        CreateTaskDto dto,
+        Guid userId);
+}

--- a/KanbAI-Core/KanbAI-Core/Services/Tasks/TaskService.cs
+++ b/KanbAI-Core/KanbAI-Core/Services/Tasks/TaskService.cs
@@ -1,0 +1,111 @@
+namespace KanbAI_Core.Services.Tasks;
+
+using KanbAI_Core.Data;
+using KanbAI_Core.DTOs;
+using KanbAI_Core.Models.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+public sealed class TaskService : ITaskService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly ILogger<TaskService> _logger;
+
+    public TaskService(ApplicationDbContext context, ILogger<TaskService> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task<(TaskResponseDto? data, CreateTaskResult result)> CreateTaskAsync(
+        Guid columnId,
+        CreateTaskDto dto,
+        Guid userId)
+    {
+        if (string.IsNullOrWhiteSpace(dto.Title))
+        {
+            return (null, CreateTaskResult.InvalidTitle);
+        }
+
+        var column = await _context.BoardColumns
+            .Include(c => c.Project)
+                .ThenInclude(p => p.Members)
+            .FirstOrDefaultAsync(c => c.Id == columnId);
+
+        if (column == null)
+        {
+            _logger.LogWarning("Column {ColumnId} not found", columnId);
+            return (null, CreateTaskResult.ColumnNotFound);
+        }
+
+        var projectMembers = column.Project.Members;
+
+        if (!projectMembers.Any(m => m.UserId == userId))
+        {
+            _logger.LogWarning(
+                "User {UserId} attempted to create a task in column {ColumnId} without project membership",
+                userId, columnId);
+            return (null, CreateTaskResult.UserNotProjectMember);
+        }
+
+        if (dto.AssignedId.HasValue)
+        {
+            var assignedId = dto.AssignedId.Value;
+
+            var assignedUserExists = await _context.Users
+                .AsNoTracking()
+                .AnyAsync(u => u.Id == assignedId);
+
+            if (!assignedUserExists)
+            {
+                _logger.LogWarning("Assigned user {AssignedId} not found", assignedId);
+                return (null, CreateTaskResult.AssignedUserNotFound);
+            }
+
+            if (!projectMembers.Any(m => m.UserId == assignedId))
+            {
+                _logger.LogWarning(
+                    "Assigned user {AssignedId} is not a member of project {ProjectId}",
+                    assignedId, column.ProjectId);
+                return (null, CreateTaskResult.AssignedUserNotProjectMember);
+            }
+        }
+
+        var maxOrder = await _context.KanbanTasks
+            .Where(t => t.ColumnId == columnId)
+            .MaxAsync(t => (int?)t.TaskOrder);
+
+        var taskOrder = (maxOrder ?? -1) + 1;
+
+        var task = new KanbanTask
+        {
+            Title = dto.Title,
+            Content = dto.Content,
+            TaskOrder = taskOrder,
+            ColumnId = columnId,
+            AssignedId = dto.AssignedId
+        };
+
+        _context.KanbanTasks.Add(task);
+        await _context.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "User {UserId} created task {TaskId} in column {ColumnId} at order {TaskOrder}",
+            userId, task.Id, columnId, task.TaskOrder);
+
+        return (MapToDto(task), CreateTaskResult.Success);
+    }
+
+    private static TaskResponseDto MapToDto(KanbanTask task) =>
+        new()
+        {
+            Id = task.Id.ToString(),
+            Title = task.Title,
+            Content = task.Content,
+            TaskOrder = task.TaskOrder,
+            ColumnId = task.ColumnId.ToString(),
+            AssignedId = task.AssignedId?.ToString(),
+            CreatedAt = task.CreatedAt,
+            UpdatedAt = task.UpdatedAt
+        };
+}

--- a/docs/handoffs/issue_46_context.md
+++ b/docs/handoffs/issue_46_context.md
@@ -1,0 +1,257 @@
+# Issue #46: Implement Kanban Task Creation and Management
+
+**GitHub Issue:** [#46 - Implement Kanban Task Creation and Management](https://github.com/Gulybi/KanbAI-Core/issues/46)  
+**Milestone:** Project and Kanban Business Logic (Issue #46 of 5)  
+**Assignee:** @Gulybi  
+**Created:** 2026-04-27
+
+---
+
+## 📊 Business Value & Context
+
+### What Are We Building?
+A Kanban Task Management API that enables project members to create and manage task cards on their boards. This includes:
+- **Creating new task cards** - Users can add tasks to specific board columns with title, content, and assigned user
+- **Assigning users to tasks** - Tasks can be assigned to specific project members for accountability
+- **Proper task ordering** - When a task is created, it is automatically positioned at the bottom (or top) of its column via the TaskOrder property
+
+### Who Is This For?
+**Project Members** (anyone with access to a project) who need to:
+- Create actionable work items (tasks) within their Kanban boards
+- Track task ownership by assigning work to specific team members
+- Organize work visually within board columns that represent workflow stages
+
+**Project Owners and Team Leads** benefit by:
+- Distributing work assignments across team members
+- Monitoring workload and task assignments through the board interface
+- Building structured workflows that reflect their team's process
+
+### Why Is This Valuable?
+**Task cards are the atomic unit of work** in a Kanban system. Without the ability to create and manage tasks:
+- Board columns exist but remain empty, providing no value to users
+- Teams cannot track individual work items, only abstract workflow stages
+- The core promise of Kanban (visualizing work in progress, limiting WIP, managing flow) cannot be fulfilled
+
+This feature transforms board columns from empty containers into actionable workflow systems where teams can capture, assign, and track individual pieces of work.
+
+---
+
+## 🗺️ Milestone Context
+
+**Milestone:** Project and Kanban Business Logic  
+**Total Issues:** 5
+
+| Issue | Title | Status | Dependency |
+|-------|-------|--------|------------|
+| #43 | Implement Project CRUD Operations | COMPLETED | Foundation |
+| #44 | Implement Project Member Management | COMPLETED | Provides user-project relationships |
+| #45 | Implement Board Columns API | COMPLETED | Provides columns for tasks to live in |
+| **#46** | **Implement Kanban Task Creation and Management** | **OPEN** | **← YOU ARE HERE** |
+| #47 | Implement Task Movement Logic | TBD | Requires #46 (tasks must exist before they can be moved) |
+
+**Prerequisites (Completed):**
+- Issue #43: Project CRUD operations exist, providing the foundation for project-scoped resources
+- Issue #44: Project Member Management exists, enabling user-to-project relationships and authorization checks
+- Issue #45: Board Columns API exists at `/api/Column/project/{projectId}` (GET, POST) and `/api/Column/{id}` (DELETE), providing the columns that tasks will belong to
+
+**Relationship to Other Issues:**
+- **Depends on #45**: Tasks cannot be created without columns to place them in. The ColumnId foreign key relationship is mandatory.
+- **Foundation for #47**: Task Movement Logic (drag-and-drop) depends on tasks existing and having TaskOrder properties that can be updated.
+
+---
+
+## 🔍 Current State vs. Desired State
+
+### Current State
+
+**Domain Model (Fully Implemented):**
+- `KanbanTask` entity exists in `KanbAI-Core/Models/Entities/KanbanTask.cs`:
+  - Properties:
+    - `Title` (string, required) - The task's headline/summary
+    - `Content` (string, nullable) - The task's detailed description
+    - `TaskOrder` (int, required) - Determines the task's position within its column
+    - `ColumnId` (Guid, foreign key, required) - The board column this task belongs to
+    - `AssignedId` (Guid, nullable) - The user assigned to this task (optional)
+  - Navigation properties:
+    - `Column` (BoardColumn) - The parent column
+    - `AssignedUser` (User, nullable) - The assigned user
+    - `Assets` (ICollection) - File attachments (future feature)
+    - `Comments` (ICollection) - Task comments (future feature)
+  - Inherits from `BaseEntity` (provides Id, CreatedAt, UpdatedAt)
+
+- `BoardColumn` entity exists in `KanbAI-Core/Models/Entities/BoardColumn.cs`:
+  - Properties include `ProjectId`, `Name`, `ColorCode`, `ColumnOrder`
+  - Navigation property `Tasks` (ICollection of KanbanTask)
+
+**API Layer (Columns Only):**
+- `ColumnController` exists in `KanbAI-Core/Controllers/ColumnController.cs`:
+  - Endpoints: GET /api/Column/project/{projectId}, POST /api/Column/project/{projectId}, DELETE /api/Column/{id}
+  - Authorization: All endpoints require [Authorize] attribute (JWT-based authentication)
+  - Helper: `GetCurrentUserId()` extracts authenticated user ID from JWT claims
+  - Response pattern: Uses `ApiResponse<T>` wrapper for standardized responses
+  - **No task management endpoints exist**
+
+**Service Layer (Columns Only):**
+- `IColumnService` interface exists in `KanbAI-Core/Services/Columns/IColumnService.cs`:
+  - Methods: `GetProjectColumnsAsync`, `CreateColumnAsync`, `DeleteColumnAsync`
+  - All methods accept `userId` parameter for authorization checks
+  - **No service or interface exists for task management**
+
+**Data Transfer Objects (Columns Only):**
+- `ColumnResponseDto`, `CreateColumnDto` exist in `KanbAI-Core/DTOs/`
+- **No DTOs exist for task operations**
+
+**Authorization Pattern (Established):**
+- Column operations verify that the user is a member of the project that owns the column
+- Pattern: Service layer checks `ProjectMembers` table for a matching `(ProjectId, UserId)` pair
+- 404 Not Found returned if project doesn't exist or user is not a member
+- This same pattern should be reused for task operations
+
+### Desired State
+
+**API Layer:**
+- New `TaskController` with RESTful endpoints for task management:
+  - **POST /api/Task/column/{columnId}** - Create a new task in a specific column
+  - Additional task management endpoints (GET, UPDATE, DELETE) as defined in technical specification
+- All endpoints return responses wrapped in the standard `ApiResponse<T>` format
+- All endpoints are protected with the `[Authorize]` attribute
+- Controller reuses the `GetCurrentUserId()` pattern from ColumnController
+
+**Service Layer:**
+- New `ITaskService` interface defining the contract for task operations
+- `TaskService` implementation handling business logic:
+  - Verifies user is a member of the project that owns the target column
+  - Automatically calculates TaskOrder when creating a task (e.g., max existing TaskOrder + 1, or 0 if no tasks exist)
+  - Validates that assigned users (if provided) are members of the project
+  - Ensures ColumnId references a valid, existing column
+
+**Data Transfer Objects:**
+- `CreateTaskDto` for task creation requests (Title, Content, AssignedId optional)
+- `TaskResponseDto` for task responses (includes all task fields plus formatted timestamps)
+- DTOs follow the `record` pattern established by existing DTOs (e.g., ColumnResponseDto)
+
+**Business Rules:**
+1. **Project membership required** - Only users who are members of the project that owns the target column can create tasks in that column
+2. **Automatic task ordering** - When a task is created, its TaskOrder is automatically set to place it at the bottom of the column (max existing TaskOrder + 1)
+3. **Optional task assignment** - The AssignedId field is nullable; tasks can be created without an assigned user
+4. **Assignment validation** - If an AssignedId is provided, it must reference a user who is a member of the project
+5. **Column existence** - The ColumnId must reference an existing column before a task can be created
+
+**Error Handling:**
+- 400 Bad Request: Title is missing/empty, ColumnId is invalid, AssignedId references non-member user
+- 403 Forbidden: User is not a member of the project that owns the column
+- 404 Not Found: Column does not exist, or user is not a member of the project
+
+---
+
+## ✅ Acceptance Criteria
+
+**As a project member, I can create a task card in a board column so that I can track actionable work items.**
+
+- [ ] A POST /api/Task/column/{columnId} endpoint exists
+- [ ] The endpoint requires a valid JWT token (authenticated user)
+- [ ] The endpoint accepts a request body containing at minimum the task Title
+- [ ] The endpoint accepts optional fields: Content (description) and AssignedId (user to assign the task to)
+- [ ] The endpoint returns 403 Forbidden if the authenticated user is not a member of the project that owns the target column
+- [ ] The endpoint returns 404 Not Found if the column does not exist
+- [ ] The endpoint returns 400 Bad Request if the Title field is missing or empty
+- [ ] Upon successful creation, the task is assigned a TaskOrder value that places it at the bottom of the column (max existing TaskOrder in that column + 1, or 0 if no tasks exist)
+- [ ] Upon successful creation, a KanbanTask record is persisted to the database with CreatedAt and UpdatedAt timestamps
+- [ ] The endpoint returns 201 Created with the newly created task's details (id, title, content, taskOrder, columnId, assignedId, createdAt, updatedAt)
+
+**As a project member, I can assign a task to a specific user so that work ownership is clear.**
+
+- [ ] When creating a task, the AssignedId field can be included in the request body
+- [ ] If AssignedId is provided and references a valid user who is a member of the project, the task is successfully created with that assignment
+- [ ] If AssignedId is provided but references a user who is NOT a member of the project, the endpoint returns 400 Bad Request with a clear error message (e.g., "Assigned user is not a member of this project.")
+- [ ] If AssignedId is provided but references a non-existent user, the endpoint returns 400 Bad Request with a clear error message (e.g., "Assigned user not found.")
+- [ ] If AssignedId is omitted or null, the task is successfully created without an assigned user
+
+**Task ordering is automatically managed to maintain visual consistency.**
+
+- [ ] When a task is created in an empty column, its TaskOrder is set to 0
+- [ ] When a task is created in a column with existing tasks, its TaskOrder is set to (maximum existing TaskOrder + 1)
+- [ ] The TaskOrder calculation happens automatically in the service layer without requiring the client to provide a TaskOrder value
+- [ ] Multiple tasks created in the same column receive unique, sequential TaskOrder values
+
+**Authorization follows the established project membership pattern.**
+
+- [ ] Task creation verifies that the authenticated user is a member of the project that owns the target column (not just that the user is authenticated)
+- [ ] The authorization check uses the same ProjectMembers table lookup pattern as ColumnService
+- [ ] If the user is not a member of the project, the endpoint returns 403 Forbidden
+- [ ] The error response uses the standard `ApiResponse.Fail()` pattern
+
+**The implementation follows existing architectural patterns.**
+
+- [ ] TaskController exists in the `KanbAI-Core/Controllers/` folder and follows the same structure as ColumnController
+- [ ] ITaskService interface exists in `KanbAI-Core/Services/Tasks/` folder
+- [ ] TaskService implementation exists and is registered in the dependency injection container
+- [ ] DTOs (CreateTaskDto, TaskResponseDto) exist in the `KanbAI-Core/DTOs/` folder and follow the record pattern
+- [ ] All responses use the `ApiResponse<T>` wrapper for consistency
+- [ ] The controller uses the same `GetCurrentUserId()` pattern to extract the authenticated user from JWT claims
+
+**Edge cases are handled gracefully.**
+
+- [ ] Attempting to create a task in a non-existent column returns 404 Not Found
+- [ ] Attempting to create a task with an empty or whitespace-only Title returns 400 Bad Request
+- [ ] Attempting to assign a task to a user who is not a project member returns 400 Bad Request with a specific error message
+- [ ] If the authenticated user's JWT is valid but they are not a member of the project, the endpoint returns 403 Forbidden (not 404)
+
+---
+
+## 🎯 Out of Scope (Future Enhancements)
+
+These capabilities are explicitly **not** part of this issue and should be deferred to future work:
+
+- **Updating existing tasks** - No PUT /api/Task/{id} endpoint (title, content, or assignment changes)
+- **Deleting tasks** - No DELETE /api/Task/{id} endpoint
+- **Fetching tasks** - No GET /api/Task/{id} or GET /api/Task/column/{columnId} endpoints (reading task lists)
+- **Moving tasks between columns** - No drag-and-drop support or TaskOrder updates (deferred to Issue #47)
+- **Task comments** - No API for creating or reading TaskComment entities
+- **Task attachments** - No API for uploading or managing Asset entities
+- **Task filtering/search** - No query parameters for filtering by assignee, column, or search terms
+- **Task metadata** - No due dates, priority levels, status flags, or labels
+- **Bulk operations** - No ability to create, update, or delete multiple tasks in a single request
+
+---
+
+## 📚 Reference Materials
+
+**Related Issues:**
+- [#43 - Implement Project CRUD Operations](https://github.com/Gulybi/KanbAI-Core/issues/43) - Foundation for ProjectController and project-scoped resources
+- [#44 - Implement Project Member Management](https://github.com/Gulybi/KanbAI-Core/issues/44) - Provides user-to-project relationships for authorization
+- [#45 - Implement Board Columns API](https://github.com/Gulybi/KanbAI-Core/issues/45) - Provides the columns that tasks belong to
+- [#47 - Implement Task Movement Logic](https://github.com/Gulybi/KanbAI-Core/issues/47) - Future feature that depends on tasks existing
+
+**Relevant Files:**
+- `KanbAI-Core/Models/Entities/KanbanTask.cs` - Task entity with Title, Content, TaskOrder, ColumnId, AssignedId
+- `KanbAI-Core/Models/Entities/BoardColumn.cs` - Column entity with Tasks navigation property
+- `KanbAI-Core/Controllers/ColumnController.cs` - Existing controller demonstrating API patterns (authorization, response wrapping)
+- `KanbAI-Core/Services/Columns/IColumnService.cs` - Existing service interface demonstrating service layer patterns
+- `KanbAI-Core/DTOs/ColumnResponseDto.cs` - Existing DTO demonstrating the record pattern and property naming conventions
+
+**Coding Standards:**
+- `.claude/rules/code-standards.md` - Modern C# conventions (file-scoped namespaces, async/await, DI patterns, EF Core optimizations)
+- `.claude/rules/security-safety.md` - Authorization checks, input validation, no PII in logs
+- `.claude/rules/testing-observability.md` - Unit test structure (AAA pattern), xUnit naming conventions
+
+---
+
+## 🚦 Success Metrics
+
+This feature is considered complete when:
+1. A project member can successfully create a task in a board column via the API with automatic TaskOrder assignment
+2. A project member can successfully assign a task to another project member during task creation
+3. A non-project-member receives a 403 Forbidden when attempting to create a task in a project's column
+4. All edge cases (empty title, non-existent column, non-member assignment) return appropriate error codes and messages
+5. The implementation passes code review with zero security vulnerabilities related to authorization bypass
+6. Integration tests demonstrate the full workflow: create project, create column, create task with and without assignment, verify task order
+
+---
+
+**Prepared by:** Product Manager Agent  
+**Date:** 2026-04-27
+
+---
+
+The business context is defined and saved. You can now instruct the staff-engineer to read the context note and design the technical specification.

--- a/docs/handoffs/issue_46_tech_spec.md
+++ b/docs/handoffs/issue_46_tech_spec.md
@@ -1,0 +1,931 @@
+# Technical Specification: Issue #46 — Implement Kanban Task Creation and Management
+
+**GitHub Issue:** [#46 - Implement Kanban Task Creation and Management](https://github.com/Gulybi/KanbAI-Core/issues/46)
+**Context Document:** [issue_46_context.md](./issue_46_context.md)
+**Staff Engineer:** @agent_staff_engineer
+**Created:** 2026-04-27
+
+---
+
+## 1. Overview
+
+This specification defines the implementation of a Kanban Task creation API that allows authenticated project members to create task cards in a board column, with optional assignment of the task to another project member. The implementation introduces a new service (`TaskService`) and controller (`TaskController`) while leveraging the existing `KanbanTask` domain entity and the project-membership authorization pattern established in Issue #45.
+
+**Scope:**
+- Create `ITaskService` interface and `TaskService` implementation.
+- Create `TaskController` exposing **one** REST endpoint: `POST /api/Task/column/{columnId}`.
+- Create two DTO records: `CreateTaskDto` (request), `TaskResponseDto` (response).
+- Implement membership-based authorization (user must be a member of the column's owning project).
+- Validate the optional `AssignedId`: referenced user must exist **and** be a member of the same project.
+- Auto-compute `TaskOrder` as `max(existing TaskOrder in the column) + 1`, or `0` when the column is empty.
+- Register `TaskService` in DI.
+
+**Out of Scope (per context note):**
+- No `GET`, `PUT`, or `DELETE` task endpoints in this issue (reserved for future issues).
+- No moving tasks between columns or reordering (deferred to Issue #47).
+- No task comments, attachments, filtering, due dates, priorities, or bulk operations.
+- **No database schema changes, entity changes, or EF Core configuration changes.** `KanbanTask`, `KanbanTaskConfiguration`, and the `KanbanTasks` migration already exist.
+
+**Why No Database Changes:**
+All required entities (`KanbanTask`, `BoardColumn`, `Project`, `ProjectMember`, `User`) and their EF configurations already exist and were introduced in Issues #23 and #26. This issue is purely an application-layer/API addition.
+
+**Design Note — Status Code Divergence from Column API:**
+The context note's "Error Handling" and Acceptance Criteria explicitly require **403 Forbidden** when the caller is not a project member (AC: *"If the authenticated user's JWT is valid but they are not a member of the project, the endpoint returns 403 Forbidden (not 404)"*). This is an intentional departure from the `ColumnService` obfuscation pattern (which conflates "not found" and "not a member" under 404). Distinguishing the two is justified here because `columnId` is a `Guid` — enumeration attacks are not practical, and explicit `403` improves diagnosability for legitimate clients. See Section 7, Caveat #1.
+
+---
+
+## 2. Database / Domain Design
+
+### 2.1 Existing Entities (No Changes Required)
+
+#### KanbanTask Entity
+
+**File:** `KanbAI-Core/KanbAI-Core/Models/Entities/KanbanTask.cs`
+
+| Property | Type | Constraints | Source |
+|----------|------|-------------|--------|
+| `Id` | `Guid` | Primary key | Inherited from `BaseEntity` |
+| `Title` | `string` | Required, max 200 chars | Direct property |
+| `Content` | `string?` | Optional | Direct property |
+| `TaskOrder` | `int` | Required | Direct property |
+| `ColumnId` | `Guid` | Foreign key to `BoardColumn` (cascade) | Direct property |
+| `AssignedId` | `Guid?` | Foreign key to `User` (set null) | Direct property |
+| `CreatedAt` | `DateTimeOffset` | Auto-set on insert | Inherited from `BaseEntity` |
+| `UpdatedAt` | `DateTimeOffset` | Auto-updated on modify | Inherited from `BaseEntity` |
+| `Column` | `BoardColumn` | Navigation | — |
+| `AssignedUser` | `User?` | Navigation | — |
+| `Assets` | `ICollection<Asset>` | Navigation (cascade from Task) | — |
+| `Comments` | `ICollection<TaskComment>` | Navigation (cascade from Task) | — |
+
+#### KanbanTaskConfiguration
+
+**File:** `KanbAI-Core/KanbAI-Core/Data/Configurations/KanbanTaskConfiguration.cs`
+
+| Property | Constraint | Purpose |
+|----------|-----------|---------|
+| `Title` | `.IsRequired().HasMaxLength(200)` | AC: Title required; enforced at DB level |
+| `Content` | (none) | Optional free-text description |
+| `TaskOrder` | `.IsRequired()` | Position within column |
+| `Column` | `.OnDelete(DeleteBehavior.Cascade)` | When column deleted, tasks are removed |
+| `AssignedUser` | `.IsRequired(false).OnDelete(DeleteBehavior.SetNull)` | When user deleted, task remains unassigned |
+
+### 2.2 Expected Database Queries (EF Core)
+
+The service will execute the following queries:
+
+| Operation | Query Pattern | Purpose |
+|-----------|---------------|---------|
+| **Load column with project + members** | `SELECT ... FROM BoardColumns c JOIN Projects p JOIN ProjectMembers m WHERE c.Id = @columnId` | Combined existence check + authorization in one round-trip |
+| **Compute next TaskOrder** | `SELECT MAX(TaskOrder) FROM KanbanTasks WHERE ColumnId = @columnId` | Auto-order new task at bottom |
+| **Validate assigned user exists** | `SELECT 1 FROM Users WHERE Id = @assignedId` (fold into member check) | AC: 400 if assigned user not found |
+| **Validate assigned user is a project member** | `SELECT 1 FROM ProjectMembers WHERE ProjectId = @projectId AND UserId = @assignedId` | AC: 400 if assigned user not a member |
+| **Insert task** | `INSERT INTO KanbanTasks ...` | Create task |
+
+**N+1 Prevention:** The column load uses `.Include(c => c.Project).ThenInclude(p => p.Members)` so a single round-trip retrieves the column, its project, and the member list. `SaveChangesAsync` triggers the `BaseEntity` timestamp override in `ApplicationDbContext`.
+
+**Read Optimization:** The column load is a **tracked** query (no `.AsNoTracking()`) — although the column entity itself isn't mutated, the membership scan operates on the loaded graph; tracking is inexpensive for a single row with a small `Members` collection and avoids subtle bugs if the service later adds navigation-property mutations. The "compute max TaskOrder" query and the member-validation query may use `.AsNoTracking()`.
+
+---
+
+## 3. API Contracts
+
+### 3.1 Endpoint Summary
+
+| Method | Route | Auth | Request Body | Response DTO | Success | Failure |
+|--------|-------|------|--------------|--------------|---------|---------|
+| POST | `/api/Task/column/{columnId}` | Required | `CreateTaskDto` | `ApiResponse<TaskResponseDto>` | 201 Created | 400, 401, 403, 404 |
+
+### 3.2 DTO Definitions
+
+#### CreateTaskDto (Request)
+
+**File:** `KanbAI-Core/KanbAI-Core/DTOs/CreateTaskDto.cs`
+
+```csharp
+namespace KanbAI_Core.DTOs;
+
+using System.ComponentModel.DataAnnotations;
+
+public record CreateTaskDto
+{
+    [Required(ErrorMessage = "Task title is required.")]
+    [MaxLength(200, ErrorMessage = "Task title cannot exceed 200 characters.")]
+    public required string Title { get; init; }
+
+    public string? Content { get; init; }
+
+    public Guid? AssignedId { get; init; }
+}
+```
+
+**Validation Rules:**
+- `Title`: Required, max 200 characters (mirrors `KanbanTaskConfiguration`).
+- `Content`: Optional free-text (no length cap at DTO level — matches the entity configuration, which has no max length).
+- `AssignedId`: Optional. When null/omitted the task is unassigned; when present it must reference an existing `User` who is a member of the column's project.
+- **Whitespace-only Title:** `[Required]` rejects `null` and `""` but does NOT reject `"   "`. The service layer adds an explicit `string.IsNullOrWhiteSpace(dto.Title)` check to satisfy AC: *"empty or whitespace-only Title returns 400 Bad Request"*.
+
+#### TaskResponseDto (Response)
+
+**File:** `KanbAI-Core/KanbAI-Core/DTOs/TaskResponseDto.cs`
+
+```csharp
+namespace KanbAI_Core.DTOs;
+
+public record TaskResponseDto
+{
+    public required string Id { get; init; }
+    public required string Title { get; init; }
+    public string? Content { get; init; }
+    public required int TaskOrder { get; init; }
+    public required string ColumnId { get; init; }
+    public string? AssignedId { get; init; }
+    public required DateTimeOffset CreatedAt { get; init; }
+    public required DateTimeOffset UpdatedAt { get; init; }
+}
+```
+
+**Property Notes:**
+- `Id`, `ColumnId`, `AssignedId`: stringified `Guid` for JSON friendliness (consistent with `ColumnResponseDto`).
+- `AssignedId` is nullable to reflect unassigned tasks.
+- `CreatedAt` / `UpdatedAt`: ISO 8601 timestamps from `BaseEntity`.
+
+### 3.3 Example API Interactions
+
+#### Example 1 — Create Task, No Assignment, Empty Column (Success)
+
+**Request:**
+```http
+POST /api/Task/column/c1a2b3c4-5d6e-7f8g-9h0i-1j2k3l4m5n6o HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
+Content-Type: application/json
+
+{
+  "title": "Design schema",
+  "content": "Draft the initial EF Core entities."
+}
+```
+
+**Response (201 Created):**
+```json
+{
+  "success": true,
+  "message": "Task created successfully.",
+  "data": {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "title": "Design schema",
+    "content": "Draft the initial EF Core entities.",
+    "taskOrder": 0,
+    "columnId": "c1a2b3c4-5d6e-7f8g-9h0i-1j2k3l4m5n6o",
+    "assignedId": null,
+    "createdAt": "2026-04-27T10:00:00Z",
+    "updatedAt": "2026-04-27T10:00:00Z"
+  },
+  "errors": []
+}
+```
+
+#### Example 2 — Create Task with Assignment, Non-Empty Column (Success)
+
+**Request:**
+```http
+POST /api/Task/column/c1a2b3c4-5d6e-7f8g-9h0i-1j2k3l4m5n6o HTTP/1.1
+Authorization: Bearer ...
+Content-Type: application/json
+
+{
+  "title": "Review PR",
+  "assignedId": "77777777-7777-7777-7777-777777777777"
+}
+```
+
+**Response (201 Created):**
+```json
+{
+  "success": true,
+  "message": "Task created successfully.",
+  "data": {
+    "id": "b2c3d4e5-...",
+    "title": "Review PR",
+    "content": null,
+    "taskOrder": 3,
+    "columnId": "c1a2b3c4-5d6e-7f8g-9h0i-1j2k3l4m5n6o",
+    "assignedId": "77777777-7777-7777-7777-777777777777",
+    "createdAt": "2026-04-27T10:05:00Z",
+    "updatedAt": "2026-04-27T10:05:00Z"
+  },
+  "errors": []
+}
+```
+
+#### Example 3 — Missing Title (Validation Failure)
+
+**Request body:**
+```json
+{ "content": "oops, no title" }
+```
+
+**Response (400 Bad Request):** — standard `[ApiController]` `ValidationProblemDetails` response (handled by framework). Also returned for whitespace-only titles via the service-layer check, wrapped as `ApiResponse.Fail("Task title is required.")`.
+
+#### Example 4 — Column Not Found
+
+**Response (404 Not Found):**
+```json
+{
+  "success": false,
+  "message": "Column not found.",
+  "errors": []
+}
+```
+
+#### Example 5 — User Not a Project Member
+
+**Response (403 Forbidden):**
+```json
+{
+  "success": false,
+  "message": "You are not a member of this project.",
+  "errors": []
+}
+```
+
+#### Example 6 — Assigned User Not a Project Member
+
+**Response (400 Bad Request):**
+```json
+{
+  "success": false,
+  "message": "Assigned user is not a member of this project.",
+  "errors": []
+}
+```
+
+#### Example 7 — Assigned User Does Not Exist
+
+**Response (400 Bad Request):**
+```json
+{
+  "success": false,
+  "message": "Assigned user not found.",
+  "errors": []
+}
+```
+
+---
+
+## 4. Application Layer Boundaries
+
+### 4.1 Result Discriminator Enum
+
+Because this endpoint must distinguish **four** failure modes (404 column-not-found, 403 caller-not-member, 400 assigned-user-not-found, 400 assigned-user-not-member) on top of the success path, the service cannot simply return `TaskResponseDto?` the way `IColumnService` does. We introduce a small discriminator enum colocated with the service.
+
+**File:** `KanbAI-Core/KanbAI-Core/Services/Tasks/CreateTaskResult.cs`
+
+```csharp
+namespace KanbAI_Core.Services.Tasks;
+
+public enum CreateTaskResult
+{
+    Success,
+    ColumnNotFound,
+    UserNotProjectMember,
+    AssignedUserNotFound,
+    AssignedUserNotProjectMember,
+    InvalidTitle
+}
+```
+
+### 4.2 ITaskService Interface
+
+**File:** `KanbAI-Core/KanbAI-Core/Services/Tasks/ITaskService.cs`
+
+```csharp
+namespace KanbAI_Core.Services.Tasks;
+
+using KanbAI_Core.DTOs;
+
+public interface ITaskService
+{
+    /// <summary>
+    /// Creates a new task in the specified column.
+    /// Authorization: the caller must be a member of the project that owns the column.
+    /// If <paramref name="dto"/>.AssignedId is provided, it must reference a user who is a member of the same project.
+    /// The new task's TaskOrder is automatically set to (max existing TaskOrder in column) + 1, or 0 if the column is empty.
+    /// </summary>
+    /// <param name="columnId">The target column ID.</param>
+    /// <param name="dto">Task creation data.</param>
+    /// <param name="userId">The authenticated user's ID (from JWT claims).</param>
+    /// <returns>A tuple containing the created task (on success) and a <see cref="CreateTaskResult"/> discriminator.</returns>
+    Task<(TaskResponseDto? data, CreateTaskResult result)> CreateTaskAsync(
+        Guid columnId,
+        CreateTaskDto dto,
+        Guid userId);
+}
+```
+
+### 4.3 TaskService Implementation
+
+**File:** `KanbAI-Core/KanbAI-Core/Services/Tasks/TaskService.cs`
+
+**Dependencies (Constructor Injection):**
+- `ApplicationDbContext _context`
+- `ILogger<TaskService> _logger`
+
+**Key Algorithm for `CreateTaskAsync`:**
+
+1. If `string.IsNullOrWhiteSpace(dto.Title)` → return `(null, InvalidTitle)`.
+2. Load the column together with its project and project members in a single query:
+   ```csharp
+   var column = await _context.BoardColumns
+       .Include(c => c.Project)
+           .ThenInclude(p => p.Members)
+       .FirstOrDefaultAsync(c => c.Id == columnId);
+   ```
+3. If `column == null` → log warning, return `(null, ColumnNotFound)`.
+4. If the caller is not a member of `column.Project`:
+   - Log warning.
+   - Return `(null, UserNotProjectMember)`.
+5. If `dto.AssignedId.HasValue`:
+   - Verify the user exists: `await _context.Users.AsNoTracking().AnyAsync(u => u.Id == dto.AssignedId.Value)`.
+     - If not → return `(null, AssignedUserNotFound)`.
+   - Verify the user is a member of `column.ProjectId`:
+     - Reuse the already-loaded `column.Project.Members` collection — no extra DB round-trip.
+     - If not → return `(null, AssignedUserNotProjectMember)`.
+6. Compute `taskOrder`:
+   ```csharp
+   var maxOrder = await _context.KanbanTasks
+       .Where(t => t.ColumnId == columnId)
+       .MaxAsync(t => (int?)t.TaskOrder);
+   int taskOrder = (maxOrder ?? -1) + 1;
+   ```
+   (Same null-projection pattern as `ColumnService.ComputeNextColumnOrderAsync`.)
+7. Construct and persist the entity:
+   ```csharp
+   var task = new KanbanTask
+   {
+       Title = dto.Title,
+       Content = dto.Content,
+       TaskOrder = taskOrder,
+       ColumnId = columnId,
+       AssignedId = dto.AssignedId
+   };
+   _context.KanbanTasks.Add(task);
+   await _context.SaveChangesAsync();
+   ```
+8. Log structured info event (`User {UserId} created task {TaskId} in column {ColumnId}`).
+9. Return `(MapToDto(task), Success)`.
+
+**Static Mapper:**
+
+```csharp
+private static TaskResponseDto MapToDto(KanbanTask task) =>
+    new()
+    {
+        Id = task.Id.ToString(),
+        Title = task.Title,
+        Content = task.Content,
+        TaskOrder = task.TaskOrder,
+        ColumnId = task.ColumnId.ToString(),
+        AssignedId = task.AssignedId?.ToString(),
+        CreatedAt = task.CreatedAt,
+        UpdatedAt = task.UpdatedAt
+    };
+```
+
+### 4.4 TaskController
+
+**File:** `KanbAI-Core/KanbAI-Core/Controllers/TaskController.cs`
+
+- `[ApiController]`, `[Route("api/[controller]")]` → `/api/Task`.
+- `[Authorize]` on the class.
+- Constructor-injects `ITaskService` and `ILogger<TaskController>`.
+- Reuses the exact `GetCurrentUserId()` helper from `ColumnController` (copy verbatim — same pattern, different logger generic type).
+
+**Endpoint Mapping:**
+
+| Result | HTTP Response |
+|--------|---------------|
+| `Success` | `201 Created` via `CreatedAtAction` — `actionName: nameof(CreateTask)`, `routeValues: new { columnId = result.ColumnId }`, body `ApiResponse<TaskResponseDto>.Ok(result, "Task created successfully.")`. There is no GET endpoint, so the `Location` header will point back at the POST route — documented in §7 Caveat #4 (matches the Column API precedent). |
+| `InvalidTitle` | `400 Bad Request` with `ApiResponse.Fail("Task title is required.")` |
+| `ColumnNotFound` | `404 Not Found` with `ApiResponse.Fail("Column not found.")` |
+| `UserNotProjectMember` | `403 Forbidden` — `StatusCode(StatusCodes.Status403Forbidden, ApiResponse.Fail("You are not a member of this project."))` |
+| `AssignedUserNotFound` | `400 Bad Request` with `ApiResponse.Fail("Assigned user not found.")` |
+| `AssignedUserNotProjectMember` | `400 Bad Request` with `ApiResponse.Fail("Assigned user is not a member of this project.")` |
+
+**Skeleton:**
+
+```csharp
+namespace KanbAI_Core.Controllers;
+
+using KanbAI_Core.DTOs;
+using KanbAI_Core.Services.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public sealed class TaskController : ControllerBase
+{
+    private readonly ITaskService _taskService;
+    private readonly ILogger<TaskController> _logger;
+
+    public TaskController(ITaskService taskService, ILogger<TaskController> logger)
+    {
+        _taskService = taskService;
+        _logger = logger;
+    }
+
+    [HttpPost("column/{columnId}")]
+    public async Task<IActionResult> CreateTask(Guid columnId, [FromBody] CreateTaskDto dto)
+    {
+        var userId = GetCurrentUserId();
+
+        var (data, result) = await _taskService.CreateTaskAsync(columnId, dto, userId);
+
+        return result switch
+        {
+            CreateTaskResult.Success =>
+                CreatedAtAction(
+                    nameof(CreateTask),
+                    new { columnId = data!.ColumnId },
+                    ApiResponse<TaskResponseDto>.Ok(data, "Task created successfully.")),
+            CreateTaskResult.ColumnNotFound =>
+                NotFound(ApiResponse.Fail("Column not found.")),
+            CreateTaskResult.UserNotProjectMember =>
+                StatusCode(StatusCodes.Status403Forbidden,
+                    ApiResponse.Fail("You are not a member of this project.")),
+            CreateTaskResult.InvalidTitle =>
+                BadRequest(ApiResponse.Fail("Task title is required.")),
+            CreateTaskResult.AssignedUserNotFound =>
+                BadRequest(ApiResponse.Fail("Assigned user not found.")),
+            CreateTaskResult.AssignedUserNotProjectMember =>
+                BadRequest(ApiResponse.Fail("Assigned user is not a member of this project.")),
+            _ => StatusCode(StatusCodes.Status500InternalServerError,
+                     ApiResponse.Fail("Unexpected error."))
+        };
+    }
+
+    private Guid GetCurrentUserId()
+    {
+        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (string.IsNullOrEmpty(userIdClaim) || !Guid.TryParse(userIdClaim, out var userId))
+        {
+            _logger.LogError("Invalid or missing NameIdentifier claim in JWT token");
+            throw new UnauthorizedAccessException("Invalid or missing user ID in token.");
+        }
+        return userId;
+    }
+}
+```
+
+---
+
+## 5. Implementation Steps for @agent_developer
+
+### Step 1 — Create the Request DTO
+
+**File:** `KanbAI-Core/KanbAI-Core/DTOs/CreateTaskDto.cs`
+Create the new folder is **not** required — `DTOs/` already exists.
+Use the exact code from §3.2 `CreateTaskDto`.
+
+### Step 2 — Create the Response DTO
+
+**File:** `KanbAI-Core/KanbAI-Core/DTOs/TaskResponseDto.cs`
+Use the exact code from §3.2 `TaskResponseDto`.
+
+### Step 3 — Create the `Services/Tasks/` Folder
+
+The folder does not yet exist. It will be created implicitly by writing the first file into it. No extra tooling step required.
+
+### Step 4 — Create the `CreateTaskResult` Enum
+
+**File:** `KanbAI-Core/KanbAI-Core/Services/Tasks/CreateTaskResult.cs`
+Use the exact code from §4.1.
+
+### Step 5 — Create the Service Interface
+
+**File:** `KanbAI-Core/KanbAI-Core/Services/Tasks/ITaskService.cs`
+Use the exact code from §4.2. Include the XML doc comment verbatim.
+
+### Step 6 — Implement `TaskService`
+
+**File:** `KanbAI-Core/KanbAI-Core/Services/Tasks/TaskService.cs`
+
+Implement the class according to the algorithm in §4.3. The full file body (synthesized from the algorithm and the project's conventions) is:
+
+```csharp
+namespace KanbAI_Core.Services.Tasks;
+
+using KanbAI_Core.Data;
+using KanbAI_Core.DTOs;
+using KanbAI_Core.Models.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+public sealed class TaskService : ITaskService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly ILogger<TaskService> _logger;
+
+    public TaskService(ApplicationDbContext context, ILogger<TaskService> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task<(TaskResponseDto? data, CreateTaskResult result)> CreateTaskAsync(
+        Guid columnId,
+        CreateTaskDto dto,
+        Guid userId)
+    {
+        if (string.IsNullOrWhiteSpace(dto.Title))
+        {
+            return (null, CreateTaskResult.InvalidTitle);
+        }
+
+        var column = await _context.BoardColumns
+            .Include(c => c.Project)
+                .ThenInclude(p => p.Members)
+            .FirstOrDefaultAsync(c => c.Id == columnId);
+
+        if (column == null)
+        {
+            _logger.LogWarning("Column {ColumnId} not found", columnId);
+            return (null, CreateTaskResult.ColumnNotFound);
+        }
+
+        var projectMembers = column.Project.Members;
+
+        if (!projectMembers.Any(m => m.UserId == userId))
+        {
+            _logger.LogWarning(
+                "User {UserId} attempted to create a task in column {ColumnId} without project membership",
+                userId, columnId);
+            return (null, CreateTaskResult.UserNotProjectMember);
+        }
+
+        if (dto.AssignedId.HasValue)
+        {
+            var assignedId = dto.AssignedId.Value;
+
+            var assignedUserExists = await _context.Users
+                .AsNoTracking()
+                .AnyAsync(u => u.Id == assignedId);
+
+            if (!assignedUserExists)
+            {
+                _logger.LogWarning("Assigned user {AssignedId} not found", assignedId);
+                return (null, CreateTaskResult.AssignedUserNotFound);
+            }
+
+            if (!projectMembers.Any(m => m.UserId == assignedId))
+            {
+                _logger.LogWarning(
+                    "Assigned user {AssignedId} is not a member of project {ProjectId}",
+                    assignedId, column.ProjectId);
+                return (null, CreateTaskResult.AssignedUserNotProjectMember);
+            }
+        }
+
+        var maxOrder = await _context.KanbanTasks
+            .Where(t => t.ColumnId == columnId)
+            .MaxAsync(t => (int?)t.TaskOrder);
+
+        var taskOrder = (maxOrder ?? -1) + 1;
+
+        var task = new KanbanTask
+        {
+            Title = dto.Title,
+            Content = dto.Content,
+            TaskOrder = taskOrder,
+            ColumnId = columnId,
+            AssignedId = dto.AssignedId
+        };
+
+        _context.KanbanTasks.Add(task);
+        await _context.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "User {UserId} created task {TaskId} in column {ColumnId} at order {TaskOrder}",
+            userId, task.Id, columnId, task.TaskOrder);
+
+        return (MapToDto(task), CreateTaskResult.Success);
+    }
+
+    private static TaskResponseDto MapToDto(KanbanTask task) =>
+        new()
+        {
+            Id = task.Id.ToString(),
+            Title = task.Title,
+            Content = task.Content,
+            TaskOrder = task.TaskOrder,
+            ColumnId = task.ColumnId.ToString(),
+            AssignedId = task.AssignedId?.ToString(),
+            CreatedAt = task.CreatedAt,
+            UpdatedAt = task.UpdatedAt
+        };
+}
+```
+
+### Step 7 — Create `TaskController`
+
+**File:** `KanbAI-Core/KanbAI-Core/Controllers/TaskController.cs`
+Use the exact skeleton from §4.4.
+
+### Step 8 — Register `TaskService` in DI
+
+**File:** `KanbAI-Core/KanbAI-Core/Program.cs`
+
+1. Add a `using` directive at the top: `using KanbAI_Core.Services.Tasks;`.
+2. Register the scoped service **immediately after** the `IColumnService` registration (line 18):
+
+```csharp
+builder.Services.AddScoped<ITaskService, TaskService>();
+```
+
+**Lifetime rationale:** `Scoped` matches `ApplicationDbContext` and all other services in this application (per `@rule_code_standards` — DbContext per request).
+
+### Step 9 — Build & Verify
+
+```bash
+cd KanbAI-Core/KanbAI-Core
+dotnet build --no-incremental
+```
+
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`. If warnings appear, do **not** suppress — fix them per `@rule_code_standards`.
+
+### Step 10 — Smoke Run (Optional)
+
+Run the app (`dotnet run`), open Scalar UI in Development, authenticate, and manually `POST /api/Task/column/{columnId}` to confirm the happy path persists to the database. This is not a substitute for automated tests — it is a quick sanity check before handing off to QA.
+
+---
+
+## 6. QA Guidance for @agent_tester_qa
+
+### 6.1 Test File Locations
+
+| Test File | Location | Type | Purpose |
+|-----------|----------|------|---------|
+| `TaskServiceTests.cs` | `KanbAI-Core.Tests/Services/Tasks/` | Unit | Business logic with EF Core in-memory DbContext |
+| `TaskControllerTests.cs` | `KanbAI-Core.Tests/Controllers/` | Unit | HTTP response mapping; claims extraction; DTO-level validation |
+| `TaskApiIntegrationTests.cs` | `KanbAI-Core.Tests/Integration/` | Integration | HTTP-level auth + validation using `WebApplicationFactory<Program>` |
+
+### 6.2 Test Case Tables
+
+#### TaskServiceTests.cs (Unit)
+
+| # | Test Name | Category | Description |
+|---|-----------|----------|-------------|
+| 1 | `CreateTaskAsync_UserIsMember_EmptyColumn_CreatesTaskWithOrderZero` | Ordering | First task in column gets `TaskOrder = 0` |
+| 2 | `CreateTaskAsync_UserIsMember_NonEmptyColumn_TaskOrderIsMaxPlusOne` | Ordering | Subsequent task gets `max + 1` |
+| 3 | `CreateTaskAsync_MultipleSequentialCreations_AssignsDistinctOrders` | Ordering | N calls → orders 0..N-1 |
+| 4 | `CreateTaskAsync_UserIsMember_NoAssignment_PersistsWithNullAssignedId` | Happy path | Unassigned task persists correctly |
+| 5 | `CreateTaskAsync_UserIsMember_ValidAssignment_PersistsWithAssignedId` | Happy path | Assigned task persists with correct FK |
+| 6 | `CreateTaskAsync_ColumnDoesNotExist_ReturnsColumnNotFound` | 404 path | `CreateTaskResult.ColumnNotFound` |
+| 7 | `CreateTaskAsync_UserNotProjectMember_ReturnsUserNotProjectMember` | 403 path | Non-member caller |
+| 8 | `CreateTaskAsync_AssignedUserDoesNotExist_ReturnsAssignedUserNotFound` | 400 path | Random Guid for `AssignedId` |
+| 9 | `CreateTaskAsync_AssignedUserIsNotProjectMember_ReturnsAssignedUserNotProjectMember` | 400 path | User exists but not in project |
+| 10 | `CreateTaskAsync_WhitespaceTitle_ReturnsInvalidTitle` | Validation | `"   "` title |
+| 11 | `CreateTaskAsync_EmptyContent_PersistsWithNullContent` | Edge case | `Content = null` is accepted |
+| 12 | `CreateTaskAsync_FailureResultPath_DoesNotPersistEntity` | Safety | After any non-Success result, DB contains no new row |
+
+#### TaskControllerTests.cs (Unit — mocked service)
+
+| # | Test Name | Category | Description |
+|---|-----------|----------|-------------|
+| 13 | `CreateTask_ServiceReturnsSuccess_Returns201CreatedWithLocationHeader` | HTTP | 201 + `Location` header present |
+| 14 | `CreateTask_ServiceReturnsColumnNotFound_Returns404` | HTTP | NotFound + `ApiResponse.Fail("Column not found.")` |
+| 15 | `CreateTask_ServiceReturnsUserNotProjectMember_Returns403` | HTTP | `StatusCode(403)` + `ApiResponse.Fail(...)` |
+| 16 | `CreateTask_ServiceReturnsAssignedUserNotFound_Returns400` | HTTP | BadRequest body matches spec |
+| 17 | `CreateTask_ServiceReturnsAssignedUserNotProjectMember_Returns400` | HTTP | BadRequest body matches spec |
+| 18 | `CreateTask_ServiceReturnsInvalidTitle_Returns400` | HTTP | BadRequest for whitespace title |
+| 19 | `CreateTask_MissingNameIdentifierClaim_ThrowsUnauthorizedAccessException` | Security | Claims extraction |
+| 20 | `CreateTaskDto_MissingTitle_FailsDataAnnotationsValidation` | Validation | `Validator.TryValidateObject` rejects missing `Title` |
+| 21 | `CreateTaskDto_TitleExceeds200Chars_FailsDataAnnotationsValidation` | Validation | 201-char title rejected |
+
+#### TaskApiIntegrationTests.cs (Integration)
+
+| # | Test Name | Category | Description |
+|---|-----------|----------|-------------|
+| 22 | `PostTask_Unauthenticated_Returns401` | Security | `[Authorize]` enforcement |
+| 23 | `PostTask_MissingTitleInBody_Returns400` | Validation | `[ApiController]` rejects missing required field |
+| 24 | `PostTask_TitleTooLong_Returns400` | Validation | `MaxLength(200)` enforced |
+
+### 6.3 Test Infrastructure
+
+- **Unit tests (service):** EF Core In-Memory provider (`Microsoft.EntityFrameworkCore.InMemory`). Seed `Project`, `ProjectMember`, `BoardColumn`, and `User` rows in `Arrange`. Use `Guid.NewGuid()` for all keys — do not hard-code.
+- **Unit tests (controller):** Mock `ITaskService` (e.g., `Mock<ITaskService>`), construct `ClaimsPrincipal` with a `NameIdentifier` claim, assign via `ControllerContext`.
+- **Integration tests:** Follow `@rule_integration_testing` exactly — register `TestAuthHandler`, remove Negotiate auth config, set `FallbackPolicy = null`. Use only HTTP-level assertions (do not seed/query the DB directly; that is what unit tests cover — see Column spec §10.4 Bug #3).
+- **Naming:** strictly `MethodName_StateUnderTest_ExpectedBehavior` per `@rule_testing_observability`.
+- **AAA layout:** blank lines between Arrange/Act/Assert.
+
+---
+
+## 7. Known Caveats
+
+| # | Caveat | Impact | Mitigation |
+|---|--------|--------|-----------|
+| 1 | **403 vs 404 divergence from ColumnService pattern** | Slightly reveals column existence to callers who know valid `columnId`s but aren't project members. | Accepted per AC #"returns 403 Forbidden (not 404)". `columnId` is a Guid → enumeration risk is negligible. Document in Caveats so future consistency reviews know this is intentional. |
+| 2 | **No update endpoint** | A task created with wrong title/assignment cannot be fixed via API. | Out of scope. Tracked for future issue. |
+| 3 | **No unique constraint on `TaskOrder`** | Two concurrent POSTs to the same column could compute the same `max+1`. | Race window is small and the outcome is still visually tolerable (two tasks with the same order — `OrderBy` is stable). Documented for the Move-Task issue #47, which will introduce proper reordering logic. No fix in this issue. |
+| 4 | **`Location` header points back at the POST route** | `CreatedAtAction(nameof(CreateTask), new { columnId }, ...)` produces `Location: /api/Task/column/{columnId}` (the same POST route) because no GET-by-id exists yet. | Same trade-off as `ColumnController` (see issue #45 spec §7). Future issue will add `GET /api/Task/{id}` and update the Location. |
+| 5 | **Whitespace title check is duplicated** | `[Required]` rejects null/empty; service rejects whitespace-only. Two layers doing similar work. | Intentional: DataAnnotations + `[ApiController]` auto-produces `ValidationProblemDetails` for null/empty (helpful for clients); service-layer check catches whitespace and returns the project's standard `ApiResponse.Fail(...)` envelope. |
+| 6 | **In-memory provider and `.MaxAsync` nullable projection** | EF Core InMemory supports the `(int?)` cast pattern used for `maxOrder`, but behavior varies across providers. | Verified against existing `ColumnService.ComputeNextColumnOrderAsync` which uses the identical pattern in production SQL Server without issue. |
+| 7 | **`column.Project` navigation is required-loaded** | If `BoardColumn.Project` were `null` (e.g., orphan row), `.ThenInclude(p => p.Members)` would NRE. | `BoardColumnConfiguration` enforces `ProjectId` as a required FK with cascade delete — orphans are impossible under the current schema. |
+| 8 | **TestServer infra** | `WebApplicationFactory` + Negotiate auth has known limitations (see `@rule_integration_testing`). | Integration tests must use the `TestAuthHandler` pattern — same as Column tests. |
+
+---
+
+## 8. Design Validation (Self-Check)
+
+| Check | Question | Status |
+|-------|----------|--------|
+| **Namespaces** | Do all referenced namespaces match `RootNamespace = KanbAI_Core` and existing conventions? | ✅ Pass — `KanbAI_Core.Controllers`, `KanbAI_Core.DTOs`, `KanbAI_Core.Services.Tasks` |
+| **Folder Paths** | Do all file paths reference real folders, or are "create new" steps included? | ✅ Pass — `Services/Tasks/` creation handled by Step 3; `Controllers/` and `DTOs/` already exist |
+| **Dependencies** | Are all required NuGet packages already in the `.csproj`, or are install steps included? | ✅ Pass — `Microsoft.EntityFrameworkCore`, `Microsoft.AspNetCore.Authentication.JwtBearer`, `System.ComponentModel.DataAnnotations` all present; no new packages |
+| **Naming Conflicts** | Do any new class/enum names conflict with existing types? | ✅ Pass — `TaskController`, `TaskService`, `ITaskService`, `CreateTaskResult`, `CreateTaskDto`, `TaskResponseDto` do **not** clash with `System.Threading.Tasks.Task` in usage (we always return `Task<...>` and reference the entity as `KanbanTask`, avoiding ambiguity). Note: if the developer encounters a `Task` ambiguity in DI or DbSet usage, fully-qualify as `KanbAI_Core.Models.Entities.KanbanTask`. |
+| **BaseEntity Compliance** | Do new entities inherit from `BaseEntity`? | ✅ N/A — no new entities; `KanbanTask` already inherits from `BaseEntity`. |
+| **Code Standards** | File-scoped namespaces, no blocking async, constructor injection, `AsNoTracking` on reads? | ✅ Pass — verified in spec sections 4 & 5 |
+| **Security** | No hardcoded secrets; no PII in logs; authorization enforced; mass-assignment prevented via DTO; input validation on DTO + service? | ✅ Pass — only `userId`/`taskId`/`columnId` (GUIDs) in logs; no `Email`, `Name`, `PasswordHash`; DTOs bound, not entities |
+
+**Result:** All checks pass. Design is ready for implementation.
+
+---
+
+**Document Status:** Ready for Implementation
+**Last Updated:** 2026-04-27
+**Next Steps:** @agent_developer should read this tech spec and begin implementation following Section 5 strictly.
+
+---
+
+## 9. Development Status
+
+**Implemented by:** @agent_developer
+**Date:** 2026-04-27
+**Status:** ✅ Complete — build passes, test suite green
+
+### 9.1 Files Created
+
+| File | Purpose |
+|------|---------|
+| `KanbAI-Core/KanbAI-Core/DTOs/CreateTaskDto.cs` | Request DTO with `[Required]` + `[MaxLength(200)]` on `Title`; optional `Content`, optional `AssignedId`. |
+| `KanbAI-Core/KanbAI-Core/DTOs/TaskResponseDto.cs` | Response DTO: stringified `Id`/`ColumnId`/`AssignedId`, timestamps from `BaseEntity`. |
+| `KanbAI-Core/KanbAI-Core/Services/Tasks/CreateTaskResult.cs` | Discriminator enum: `Success`, `ColumnNotFound`, `UserNotProjectMember`, `AssignedUserNotFound`, `AssignedUserNotProjectMember`, `InvalidTitle`. |
+| `KanbAI-Core/KanbAI-Core/Services/Tasks/ITaskService.cs` | Service contract — single `CreateTaskAsync` method returning `(TaskResponseDto?, CreateTaskResult)`. |
+| `KanbAI-Core/KanbAI-Core/Services/Tasks/TaskService.cs` | Implementation per §4.3 algorithm. Single column-load round-trip with `.Include(c => c.Project).ThenInclude(p => p.Members)`. Reuses loaded `Members` collection to validate `AssignedId` membership (no extra DB call). `.AsNoTracking()` on user existence check. `MaxAsync((int?)TaskOrder)` pattern mirrors `ColumnService.ComputeNextColumnOrderAsync`. |
+| `KanbAI-Core/KanbAI-Core/Controllers/TaskController.cs` | `[ApiController]`/`[Authorize]`, one endpoint `POST /api/Task/column/{columnId}`. Pattern-match switch maps `CreateTaskResult` → HTTP response. `GetCurrentUserId()` copied verbatim from `ColumnController`. |
+
+### 9.2 Files Modified
+
+| File | Change |
+|------|--------|
+| `KanbAI-Core/KanbAI-Core/Program.cs` | Added `using KanbAI_Core.Services.Tasks;` and `builder.Services.AddScoped<ITaskService, TaskService>();` immediately after the `IColumnService` registration. |
+
+### 9.3 Files NOT Modified (Intentional, per spec §1 "Out of Scope")
+
+- `Models/Entities/KanbanTask.cs` — already correct.
+- `Data/Configurations/KanbanTaskConfiguration.cs` — already correct.
+- `Data/ApplicationDbContext.cs` — `KanbanTasks` DbSet already exists.
+- No new migration was generated — zero schema changes.
+
+### 9.4 Build & Test Results
+
+**Build (main project):**
+```
+dotnet build --no-incremental
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+Time Elapsed 00:00:10.67
+```
+
+**Test suite (solution-wide):**
+```
+dotnet test --verbosity quiet
+Passed!  - Failed:     0, Passed:   311, Skipped:     2, Total:   313, Duration: 4 s
+```
+
+- No new tests were added in this phase — automated tests are QA's responsibility per the workflow.
+- All 311 pre-existing tests continue to pass.
+- The 2 skipped tests are pre-existing and unrelated to this change.
+
+### 9.5 Infrastructure Notes
+
+None. The implementation is pure application/API-layer code — no tooling, no migrations, no config changes beyond the single DI line in `Program.cs`.
+
+### 9.6 Edge Cases for @agent_tester_qa
+
+The QA tester should pay particular attention to the following behaviours, which are easy to regress:
+
+1. **`TaskOrder` computation on empty column** — `maxOrder` returns `null` via `(int?)` projection, which collapses to `-1 + 1 = 0`. Verify the first task in a fresh column gets `TaskOrder = 0` (not `1`).
+2. **Whitespace-only Title** — rejected by the explicit `string.IsNullOrWhiteSpace` check in the service (NOT by `[Required]`). Make sure the integration-level test for whitespace titles asserts the service-layer path (returns `CreateTaskResult.InvalidTitle` → 400 with `"Task title is required."` body), distinct from the framework `ValidationProblemDetails` returned for missing/empty titles.
+3. **403 vs 404 divergence** — This endpoint deliberately returns **403** when the caller isn't a project member (see §7 Caveat #1), unlike `ColumnController` which returns 404. Assertions must pin this to 403 exactly.
+4. **Assigned user dual-check** — Two distinct 400 paths: `AssignedUserNotFound` (user doesn't exist at all) vs `AssignedUserNotProjectMember` (user exists but isn't in this project). Both return 400 but with different messages; tests should assert on the message string.
+5. **Reusing the loaded `Members` collection** — the service validates the assigned user's membership against `column.Project.Members` (already materialized), NOT via a fresh query. Unit tests with the in-memory provider must set up `ProjectMember` rows before the column is loaded — not after — or the check will miss them.
+6. **`CreatedAtAction` Location header** — points back at the same POST route (`/api/Task/column/{columnId}`) because no GET-by-id exists yet. Tests should assert the header is present but not be strict about the URL format (see §7 Caveat #4).
+7. **Tracking semantics** — the column-load query is intentionally NOT `.AsNoTracking()` (see §2.2 "Read Optimization"). If QA writes a test that asserts zero entries in `ChangeTracker.Entries()` after `CreateTaskAsync`, it will fail. This is expected.
+8. **Race on concurrent POSTs** — `max(TaskOrder) + 1` is not transactional. Two parallel POSTs to the same column can produce duplicate orders. Documented as Caveat #3; do not write a test that fails on this (it's a known limitation tracked for issue #47).
+
+### 9.7 Self-Validation
+
+All checks from Step 5 of the developer workflow pass:
+
+| Check | Status |
+|-------|--------|
+| File placement matches spec | ✅ |
+| Namespaces match `RootNamespace = KanbAI_Core` | ✅ |
+| File-scoped namespaces used everywhere | ✅ |
+| Constructor injection, async-only, no `.Result`/`.Wait()` | ✅ |
+| `.AsNoTracking()` on user-existence check | ✅ |
+| N+1 prevented via `.Include`/`.ThenInclude` | ✅ |
+| No hardcoded secrets, no PII in logs (only GUIDs) | ✅ |
+| DTO-bound (mass-assignment prevention) | ✅ |
+| Tech spec fidelity — every file listed in §5 implemented verbatim | ✅ |
+| No extras beyond the spec | ✅ |
+| No schema / migration changes | ✅ (per §1) |
+
+---
+
+## 10. QA Status
+
+**Tested by:** @agent_tester_qa
+**Date:** 2026-04-27
+**Status:** ✅ Complete — all 29 new tests pass, no regressions
+
+### 10.1 Test Files Created
+
+| File | Type | Tests | Coverage |
+|------|------|-------|----------|
+| [KanbAI-Core/KanbAI-Core.Tests/Services/Tasks/TaskServiceTests.cs](../../KanbAI-Core/KanbAI-Core.Tests/Services/Tasks/TaskServiceTests.cs) | Unit (EF Core In-Memory) | 14 | Full `CreateTaskAsync` algorithm: ordering (0, max+1, sequential), happy paths (unassigned/assigned), four failure discriminators (ColumnNotFound / UserNotProjectMember / AssignedUserNotFound / AssignedUserNotProjectMember), whitespace-title theory, null content, multi-failure no-persist safety |
+| [KanbAI-Core/KanbAI-Core.Tests/Controllers/TaskControllerTests.cs](../../KanbAI-Core/KanbAI-Core.Tests/Controllers/TaskControllerTests.cs) | Unit (mocked `ITaskService`) | 11 | All six `CreateTaskResult` → HTTP mappings, `CreatedAtAction` Location routing, missing claim + invalid claim `UnauthorizedAccessException`, DTO DataAnnotations validation (missing/too-long/boundary Title) |
+| [KanbAI-Core/KanbAI-Core.Tests/Integration/TaskApiIntegrationTests.cs](../../KanbAI-Core/KanbAI-Core.Tests/Integration/TaskApiIntegrationTests.cs) | Integration (`WebApplicationFactory<Program>`) | 4 | `[Authorize]` enforcement (401), `[ApiController]` DTO validation (missing / empty / too-long Title → 400) |
+
+### 10.2 Test Results
+
+```
+dotnet test --filter "FullyQualifiedName~TaskServiceTests|FullyQualifiedName~TaskControllerTests|FullyQualifiedName~TaskApiIntegrationTests"
+Passed!  - Failed:     0, Passed:    29, Skipped:     0, Total:    29, Duration: 2 s
+
+dotnet test (solution-wide)
+Total tests: 342
+     Passed: 340
+    Skipped: 2 (pre-existing, unrelated)
+Total time: 7.2 Seconds
+```
+
+- **29 new tests added** (311 → 340 passing).
+- **Zero regressions** in the pre-existing 311-test suite.
+- **Zero build warnings**, zero errors.
+
+### 10.3 Acceptance Criteria Coverage
+
+Every AC from `issue_46_context.md` is validated by at least one test:
+
+| Acceptance Criterion | Covered By |
+|---------------------|-----------|
+| POST endpoint exists at `/api/Task/column/{columnId}` | `PostTask_*` integration suite |
+| Endpoint requires valid JWT | `PostTask_Unauthenticated_Returns401` |
+| Accepts minimum Title in body | `CreateTaskAsync_UserIsMember_EmptyColumn_CreatesTaskWithOrderZero` |
+| Accepts optional Content / AssignedId | `CreateTaskAsync_EmptyContent_PersistsWithNullContent`, `CreateTaskAsync_UserIsMember_ValidAssignment_PersistsWithAssignedId` |
+| 403 when caller not a project member | `CreateTaskAsync_UserNotProjectMember_ReturnsUserNotProjectMember` + `CreateTask_ServiceReturnsUserNotProjectMember_Returns403` |
+| 404 when column does not exist | `CreateTaskAsync_ColumnDoesNotExist_ReturnsColumnNotFound` + `CreateTask_ServiceReturnsColumnNotFound_Returns404` |
+| 400 when Title missing or empty | `PostTask_MissingTitleInBody_Returns400`, `PostTask_EmptyTitleInBody_Returns400`, `CreateTaskDto_MissingTitle_FailsDataAnnotationsValidation` |
+| 400 when Title whitespace-only | `CreateTaskAsync_WhitespaceTitle_ReturnsInvalidTitle` theory (`"   "`, `"\t"`, `"\n"`) + `CreateTask_ServiceReturnsInvalidTitle_Returns400` |
+| TaskOrder = 0 in empty column | `CreateTaskAsync_UserIsMember_EmptyColumn_CreatesTaskWithOrderZero` |
+| TaskOrder = max + 1 in populated column | `CreateTaskAsync_UserIsMember_NonEmptyColumn_TaskOrderIsMaxPlusOne` |
+| Sequential creations get distinct orders | `CreateTaskAsync_MultipleSequentialCreations_AssignsDistinctOrders` |
+| 201 Created with task details and Location header | `CreateTask_ServiceReturnsSuccess_Returns201CreatedWithLocationHeader` |
+| CreatedAt / UpdatedAt timestamps set by BaseEntity | Verified via `TaskResponseDto` assertions on success tests |
+| AssignedId: valid member → success | `CreateTaskAsync_UserIsMember_ValidAssignment_PersistsWithAssignedId` |
+| AssignedId: existing user but not member → 400 | `CreateTaskAsync_AssignedUserIsNotProjectMember_ReturnsAssignedUserNotProjectMember` + `CreateTask_ServiceReturnsAssignedUserNotProjectMember_Returns400` |
+| AssignedId: non-existent user → 400 | `CreateTaskAsync_AssignedUserDoesNotExist_ReturnsAssignedUserNotFound` + `CreateTask_ServiceReturnsAssignedUserNotFound_Returns400` |
+| AssignedId omitted/null → success unassigned | `CreateTaskAsync_UserIsMember_NoAssignment_PersistsWithNullAssignedId` |
+| 403 vs 404 divergence (not collapsed to 404) | `CreateTask_ServiceReturnsUserNotProjectMember_Returns403` asserts `StatusCodes.Status403Forbidden` exactly |
+| Title > 200 chars rejected | `CreateTaskDto_TitleExceeds200Chars_FailsDataAnnotationsValidation`, `PostTask_TitleTooLong_Returns400` |
+
+### 10.4 Bugs Found & Fixed
+
+**None.** Implementation matched the tech spec precisely, and every test passed on first run. No production-code changes were required.
+
+### 10.5 Edge-Case Handling Verified
+
+Per §9.6 ("Edge Cases for @agent_tester_qa"), I verified each of the eight callouts:
+
+1. **TaskOrder on empty column = 0** — Confirmed by `CreateTaskAsync_UserIsMember_EmptyColumn_CreatesTaskWithOrderZero`.
+2. **Whitespace title rejected by service (not DataAnnotations)** — Theory covers `"   "`, `"\t"`, `"\n"`; `CreateTask_ServiceReturnsInvalidTitle_Returns400` confirms the 400 + `"Task title is required."` message from the service path, distinct from the framework `ValidationProblemDetails` path verified in `PostTask_EmptyTitleInBody_Returns400`.
+3. **403 vs 404 divergence pinned** — `CreateTask_ServiceReturnsUserNotProjectMember_Returns403` asserts status code equals `StatusCodes.Status403Forbidden`.
+4. **Two 400 paths distinguished by message** — `AssignedUserNotFound` asserts `"Assigned user not found."`; `AssignedUserNotProjectMember` asserts `"Assigned user is not a member of this project."`.
+5. **Reuses loaded Members collection** — Seed order in `SeedProjectWithColumnAsync` inserts members **before** the column-load query runs in the service, matching the tech spec's warning.
+6. **Location header** — Assertion checks presence + `RouteValues["columnId"]` matches the response `ColumnId`, without pinning the exact URL format (per Caveat #4).
+7. **Tracking semantics** — No test asserts on `ChangeTracker.Entries()`; only persisted entity state is verified.
+8. **Concurrent POST race** — Not tested; acknowledged as known limitation per Caveat #3 (to be fixed in Issue #47).
+
+### 10.6 Outstanding Issues
+
+**None.** All acceptance criteria are covered, all tests pass, and no bugs were discovered. The implementation is ready for merge.
+
+---
+
+QA testing is complete. All tests pass and the implementation meets the acceptance criteria.
+


### PR DESCRIPTION
Implement the `POST /api/Task/column/{columnId}` endpoint to enable creation of Kanban tasks. This introduces the `TaskController`, `ITaskService`, `TaskService`, and associated DTOs.

Key features:
- Automatic calculation of `TaskOrder` (0 for empty columns, max+1 otherwise).
- Project membership-based authorization for task creation.
- Validation for optional task assignment to project members.
- Comprehensive unit and integration test suite.
- Updates to documentation and Claude agent settings.

Fixes #46