### PR TITLE
47 implement Kanban task movement and reordering logic (#47)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,8 @@
       "Bash(awk '{print $NF}')",
       "Bash(grep \"\\\\.cs$\")",
       "Bash(xargs -I {} find {} -type f -name \"*.cs\")",
-      "Bash(xargs grep *)"
+      "Bash(xargs grep *)",
+      "Bash(grep -E \"\\\\.cs$\")"
     ],
     "additionalDirectories": [
       "C:\\temp\\KanbAI-Core\\.claude"

--- a/KanbAI-Core/KanbAI-Core.Tests/Controllers/TaskControllerTests.cs
+++ b/KanbAI-Core/KanbAI-Core.Tests/Controllers/TaskControllerTests.cs
@@ -252,6 +252,220 @@ public class TaskControllerTests
 
     #endregion
 
+    #region MoveTask HTTP Mapping Tests
+
+    [Fact]
+    public async Task MoveTask_ServiceReturnsSuccess_Returns200OK()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var taskId = Guid.NewGuid();
+        var columnId = Guid.NewGuid();
+        SetupUserClaims(userId);
+
+        var dto = new MoveTaskDto { ColumnId = columnId, TaskOrder = 1 };
+        var responseDto = new TaskResponseDto
+        {
+            Id = taskId.ToString(),
+            Title = "Moved Task",
+            Content = null,
+            TaskOrder = 1,
+            ColumnId = columnId.ToString(),
+            AssignedId = null,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        _taskServiceMock
+            .Setup(s => s.MoveTaskAsync(taskId, dto, userId))
+            .ReturnsAsync((responseDto, MoveTaskResult.Success));
+
+        // Act
+        var result = await _controller.MoveTask(taskId, dto);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.StatusCode.Should().Be(200);
+
+        var apiResponse = okResult.Value.Should().BeOfType<ApiResponse<TaskResponseDto>>().Subject;
+        apiResponse.Success.Should().BeTrue();
+        apiResponse.Message.Should().Be("Task moved successfully.");
+        apiResponse.Data.Should().BeEquivalentTo(responseDto);
+    }
+
+    [Fact]
+    public async Task MoveTask_ServiceReturnsTaskNotFound_Returns404()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var taskId = Guid.NewGuid();
+        var columnId = Guid.NewGuid();
+        SetupUserClaims(userId);
+
+        var dto = new MoveTaskDto { ColumnId = columnId, TaskOrder = 0 };
+
+        _taskServiceMock
+            .Setup(s => s.MoveTaskAsync(taskId, dto, userId))
+            .ReturnsAsync((null, MoveTaskResult.TaskNotFound));
+
+        // Act
+        var result = await _controller.MoveTask(taskId, dto);
+
+        // Assert
+        var notFound = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFound.StatusCode.Should().Be(404);
+
+        var apiResponse = notFound.Value.Should().BeOfType<ApiResponse>().Subject;
+        apiResponse.Success.Should().BeFalse();
+        apiResponse.Message.Should().Be("Task not found.");
+    }
+
+    [Fact]
+    public async Task MoveTask_ServiceReturnsUserNotProjectMember_Returns403()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var taskId = Guid.NewGuid();
+        var columnId = Guid.NewGuid();
+        SetupUserClaims(userId);
+
+        var dto = new MoveTaskDto { ColumnId = columnId, TaskOrder = 0 };
+
+        _taskServiceMock
+            .Setup(s => s.MoveTaskAsync(taskId, dto, userId))
+            .ReturnsAsync((null, MoveTaskResult.UserNotProjectMember));
+
+        // Act
+        var result = await _controller.MoveTask(taskId, dto);
+
+        // Assert
+        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+
+        var apiResponse = objectResult.Value.Should().BeOfType<ApiResponse>().Subject;
+        apiResponse.Success.Should().BeFalse();
+        apiResponse.Message.Should().Be("You are not a member of this project.");
+    }
+
+    [Fact]
+    public async Task MoveTask_ServiceReturnsTargetColumnNotFound_Returns404()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var taskId = Guid.NewGuid();
+        var columnId = Guid.NewGuid();
+        SetupUserClaims(userId);
+
+        var dto = new MoveTaskDto { ColumnId = columnId, TaskOrder = 0 };
+
+        _taskServiceMock
+            .Setup(s => s.MoveTaskAsync(taskId, dto, userId))
+            .ReturnsAsync((null, MoveTaskResult.TargetColumnNotFound));
+
+        // Act
+        var result = await _controller.MoveTask(taskId, dto);
+
+        // Assert
+        var notFound = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFound.StatusCode.Should().Be(404);
+
+        var apiResponse = notFound.Value.Should().BeOfType<ApiResponse>().Subject;
+        apiResponse.Success.Should().BeFalse();
+        apiResponse.Message.Should().Be("Target column not found.");
+    }
+
+    [Fact]
+    public async Task MoveTask_ServiceReturnsCrossProjectMove_Returns400()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var taskId = Guid.NewGuid();
+        var columnId = Guid.NewGuid();
+        SetupUserClaims(userId);
+
+        var dto = new MoveTaskDto { ColumnId = columnId, TaskOrder = 0 };
+
+        _taskServiceMock
+            .Setup(s => s.MoveTaskAsync(taskId, dto, userId))
+            .ReturnsAsync((null, MoveTaskResult.CrossProjectMove));
+
+        // Act
+        var result = await _controller.MoveTask(taskId, dto);
+
+        // Assert
+        var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badRequest.StatusCode.Should().Be(400);
+
+        var apiResponse = badRequest.Value.Should().BeOfType<ApiResponse>().Subject;
+        apiResponse.Success.Should().BeFalse();
+        apiResponse.Message.Should().Be("Cannot move task to a column in a different project.");
+    }
+
+    [Fact]
+    public async Task MoveTask_ServiceReturnsInvalidTaskOrder_Returns400()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var taskId = Guid.NewGuid();
+        var columnId = Guid.NewGuid();
+        SetupUserClaims(userId);
+
+        var dto = new MoveTaskDto { ColumnId = columnId, TaskOrder = 99 };
+
+        _taskServiceMock
+            .Setup(s => s.MoveTaskAsync(taskId, dto, userId))
+            .ReturnsAsync((null, MoveTaskResult.InvalidTaskOrder));
+
+        // Act
+        var result = await _controller.MoveTask(taskId, dto);
+
+        // Assert
+        var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badRequest.StatusCode.Should().Be(400);
+
+        var apiResponse = badRequest.Value.Should().BeOfType<ApiResponse>().Subject;
+        apiResponse.Success.Should().BeFalse();
+        apiResponse.Message.Should().Be("TaskOrder is invalid.");
+    }
+
+    #endregion
+
+    #region MoveTaskDto Validation Tests
+
+    [Fact]
+    public void MoveTaskDto_NegativeTaskOrder_FailsDataAnnotationsValidation()
+    {
+        // Arrange
+        var dto = new MoveTaskDto { ColumnId = Guid.NewGuid(), TaskOrder = -1 };
+
+        // Act
+        var validationContext = new ValidationContext(dto);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(dto, validationContext, validationResults, true);
+
+        // Assert
+        isValid.Should().BeFalse();
+        validationResults.Should().Contain(vr => vr.MemberNames.Contains("TaskOrder"));
+    }
+
+    [Fact]
+    public void MoveTaskDto_ZeroTaskOrder_PassesDataAnnotationsValidation()
+    {
+        // Arrange
+        var dto = new MoveTaskDto { ColumnId = Guid.NewGuid(), TaskOrder = 0 };
+
+        // Act
+        var validationContext = new ValidationContext(dto);
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(dto, validationContext, validationResults, true);
+
+        // Assert
+        isValid.Should().BeTrue();
+        validationResults.Should().BeEmpty();
+    }
+
+    #endregion
+
     #region DTO Validation Tests
 
     [Fact]

--- a/KanbAI-Core/KanbAI-Core.Tests/Integration/TaskApiIntegrationTests.cs
+++ b/KanbAI-Core/KanbAI-Core.Tests/Integration/TaskApiIntegrationTests.cs
@@ -102,6 +102,59 @@ public class TaskApiIntegrationTests : IClassFixture<CustomWebApplicationFactory
 
     #endregion
 
+    #region MoveTask Security & Validation Tests
+
+    [Fact]
+    public async Task PutMoveTask_Unauthenticated_Returns401()
+    {
+        // Arrange
+        var client = CreateUnauthenticatedClient();
+        var taskId = Guid.NewGuid();
+        var dto = new MoveTaskDto { ColumnId = Guid.NewGuid(), TaskOrder = 0 };
+
+        // Act
+        var response = await client.PutAsJsonAsync($"/api/task/{taskId}/move", dto);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task PutMoveTask_MissingColumnId_Returns400()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var client = CreateAuthenticatedClient(userId);
+        var taskId = Guid.NewGuid();
+
+        var invalidBody = new { taskOrder = 0 };
+
+        // Act
+        var response = await client.PutAsJsonAsync($"/api/task/{taskId}/move", invalidBody);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task PutMoveTask_NegativeTaskOrder_Returns400()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var client = CreateAuthenticatedClient(userId);
+        var taskId = Guid.NewGuid();
+
+        var body = new { columnId = Guid.NewGuid(), taskOrder = -1 };
+
+        // Act
+        var response = await client.PutAsJsonAsync($"/api/task/{taskId}/move", body);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    #endregion
+
     #region Test Infrastructure
 
     private HttpClient CreateAuthenticatedClient(Guid userId)

--- a/KanbAI-Core/KanbAI-Core.Tests/Services/Tasks/TaskServiceMoveTests.cs
+++ b/KanbAI-Core/KanbAI-Core.Tests/Services/Tasks/TaskServiceMoveTests.cs
@@ -1,0 +1,622 @@
+using FluentAssertions;
+using KanbAI_Core.Data;
+using KanbAI_Core.DTOs;
+using KanbAI_Core.Models.Entities;
+using KanbAI_Core.Models.Enums;
+using KanbAI_Core.Services.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace KanbAI_Core.Tests.Services.Tasks;
+
+public class TaskServiceMoveTests
+{
+    private readonly Mock<ILogger<TaskService>> _loggerMock;
+
+    public TaskServiceMoveTests()
+    {
+        _loggerMock = new Mock<ILogger<TaskService>>();
+    }
+
+    #region Cross-Column Moves
+
+    [Fact]
+    public async Task MoveTaskAsync_DifferentColumn_UpdatesColumnIdAndTaskOrder()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, sourceColumnId, targetColumnId) = await SeedProjectWithTwoColumnsAsync(context, userId);
+
+        var movedTaskId = Guid.NewGuid();
+        context.KanbanTasks.AddRange(
+            new KanbanTask { Id = Guid.NewGuid(), Title = "A", TaskOrder = 0, ColumnId = sourceColumnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "B", TaskOrder = 1, ColumnId = sourceColumnId },
+            new KanbanTask { Id = movedTaskId, Title = "C", TaskOrder = 2, ColumnId = sourceColumnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "X", TaskOrder = 0, ColumnId = targetColumnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "Y", TaskOrder = 1, ColumnId = targetColumnId });
+        await context.SaveChangesAsync();
+
+        var dto = new MoveTaskDto { ColumnId = targetColumnId, TaskOrder = 1 };
+
+        // Act
+        var (data, result) = await service.MoveTaskAsync(movedTaskId, dto, userId);
+
+        // Assert
+        result.Should().Be(MoveTaskResult.Success);
+        data.Should().NotBeNull();
+        data!.ColumnId.Should().Be(targetColumnId.ToString());
+        data.TaskOrder.Should().Be(1);
+
+        var movedTask = await context.KanbanTasks.AsNoTracking().SingleAsync(t => t.Id == movedTaskId);
+        movedTask.ColumnId.Should().Be(targetColumnId);
+        movedTask.TaskOrder.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MoveTaskAsync_DifferentColumn_RecalculatesSourceColumnOrders()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, sourceColumnId, targetColumnId) = await SeedProjectWithTwoColumnsAsync(context, userId);
+
+        var movedTaskId = Guid.NewGuid();
+        context.KanbanTasks.AddRange(
+            new KanbanTask { Id = Guid.NewGuid(), Title = "A", TaskOrder = 0, ColumnId = sourceColumnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "B", TaskOrder = 1, ColumnId = sourceColumnId },
+            new KanbanTask { Id = movedTaskId, Title = "C", TaskOrder = 2, ColumnId = sourceColumnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "D", TaskOrder = 3, ColumnId = sourceColumnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "E", TaskOrder = 4, ColumnId = sourceColumnId });
+        await context.SaveChangesAsync();
+
+        var dto = new MoveTaskDto { ColumnId = targetColumnId, TaskOrder = 0 };
+
+        // Act
+        var (_, result) = await service.MoveTaskAsync(movedTaskId, dto, userId);
+
+        // Assert
+        result.Should().Be(MoveTaskResult.Success);
+
+        var sourceOrders = await context.KanbanTasks
+            .AsNoTracking()
+            .Where(t => t.ColumnId == sourceColumnId)
+            .OrderBy(t => t.TaskOrder)
+            .Select(t => new { t.Title, t.TaskOrder })
+            .ToListAsync();
+
+        sourceOrders.Should().HaveCount(4);
+        sourceOrders.Select(x => x.TaskOrder).Should().Equal(0, 1, 2, 3);
+        sourceOrders.Select(x => x.Title).Should().Equal("A", "B", "D", "E");
+    }
+
+    [Fact]
+    public async Task MoveTaskAsync_DifferentColumn_RecalculatesTargetColumnOrders()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, sourceColumnId, targetColumnId) = await SeedProjectWithTwoColumnsAsync(context, userId);
+
+        var movedTaskId = Guid.NewGuid();
+        context.KanbanTasks.AddRange(
+            new KanbanTask { Id = movedTaskId, Title = "M", TaskOrder = 0, ColumnId = sourceColumnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "X", TaskOrder = 0, ColumnId = targetColumnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "Y", TaskOrder = 1, ColumnId = targetColumnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "Z", TaskOrder = 2, ColumnId = targetColumnId });
+        await context.SaveChangesAsync();
+
+        var dto = new MoveTaskDto { ColumnId = targetColumnId, TaskOrder = 1 };
+
+        // Act
+        var (_, result) = await service.MoveTaskAsync(movedTaskId, dto, userId);
+
+        // Assert
+        result.Should().Be(MoveTaskResult.Success);
+
+        var targetOrders = await context.KanbanTasks
+            .AsNoTracking()
+            .Where(t => t.ColumnId == targetColumnId)
+            .OrderBy(t => t.TaskOrder)
+            .Select(t => new { t.Title, t.TaskOrder })
+            .ToListAsync();
+
+        targetOrders.Should().HaveCount(4);
+        targetOrders.Select(x => x.TaskOrder).Should().Equal(0, 1, 2, 3);
+        targetOrders.Select(x => x.Title).Should().Equal("X", "M", "Y", "Z");
+    }
+
+    [Fact]
+    public async Task MoveTaskAsync_DifferentColumn_AppendToEnd_AddsAtBoundary()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, sourceColumnId, targetColumnId) = await SeedProjectWithTwoColumnsAsync(context, userId);
+
+        var movedTaskId = Guid.NewGuid();
+        context.KanbanTasks.AddRange(
+            new KanbanTask { Id = movedTaskId, Title = "M", TaskOrder = 0, ColumnId = sourceColumnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "X", TaskOrder = 0, ColumnId = targetColumnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "Y", TaskOrder = 1, ColumnId = targetColumnId });
+        await context.SaveChangesAsync();
+
+        // TaskOrder = 2 is the count of tasks in target column → valid "append" position
+        var dto = new MoveTaskDto { ColumnId = targetColumnId, TaskOrder = 2 };
+
+        // Act
+        var (data, result) = await service.MoveTaskAsync(movedTaskId, dto, userId);
+
+        // Assert
+        result.Should().Be(MoveTaskResult.Success);
+        data!.TaskOrder.Should().Be(2);
+
+        var targetOrders = await context.KanbanTasks
+            .AsNoTracking()
+            .Where(t => t.ColumnId == targetColumnId)
+            .OrderBy(t => t.TaskOrder)
+            .Select(t => new { t.Title, t.TaskOrder })
+            .ToListAsync();
+
+        targetOrders.Select(x => x.TaskOrder).Should().Equal(0, 1, 2);
+        targetOrders.Select(x => x.Title).Should().Equal("X", "Y", "M");
+    }
+
+    #endregion
+
+    #region Same-Column Reorder
+
+    [Fact]
+    public async Task MoveTaskAsync_SameColumn_MoveUp_RecalculatesOrders()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId, _) = await SeedProjectWithTwoColumnsAsync(context, userId);
+
+        var movedTaskId = Guid.NewGuid();
+        context.KanbanTasks.AddRange(
+            new KanbanTask { Id = Guid.NewGuid(), Title = "A", TaskOrder = 0, ColumnId = columnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "B", TaskOrder = 1, ColumnId = columnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "C", TaskOrder = 2, ColumnId = columnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "D", TaskOrder = 3, ColumnId = columnId },
+            new KanbanTask { Id = movedTaskId, Title = "E", TaskOrder = 4, ColumnId = columnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "F", TaskOrder = 5, ColumnId = columnId });
+        await context.SaveChangesAsync();
+
+        var dto = new MoveTaskDto { ColumnId = columnId, TaskOrder = 1 };
+
+        // Act
+        var (data, result) = await service.MoveTaskAsync(movedTaskId, dto, userId);
+
+        // Assert
+        result.Should().Be(MoveTaskResult.Success);
+        data!.TaskOrder.Should().Be(1);
+
+        var orders = await context.KanbanTasks
+            .AsNoTracking()
+            .Where(t => t.ColumnId == columnId)
+            .OrderBy(t => t.TaskOrder)
+            .Select(t => new { t.Title, t.TaskOrder })
+            .ToListAsync();
+
+        orders.Select(x => x.TaskOrder).Should().Equal(0, 1, 2, 3, 4, 5);
+        orders.Select(x => x.Title).Should().Equal("A", "E", "B", "C", "D", "F");
+    }
+
+    [Fact]
+    public async Task MoveTaskAsync_SameColumn_MoveDown_RecalculatesOrders()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId, _) = await SeedProjectWithTwoColumnsAsync(context, userId);
+
+        var movedTaskId = Guid.NewGuid();
+        context.KanbanTasks.AddRange(
+            new KanbanTask { Id = Guid.NewGuid(), Title = "A", TaskOrder = 0, ColumnId = columnId },
+            new KanbanTask { Id = movedTaskId, Title = "B", TaskOrder = 1, ColumnId = columnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "C", TaskOrder = 2, ColumnId = columnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "D", TaskOrder = 3, ColumnId = columnId });
+        await context.SaveChangesAsync();
+
+        var dto = new MoveTaskDto { ColumnId = columnId, TaskOrder = 3 };
+
+        // Act
+        var (data, result) = await service.MoveTaskAsync(movedTaskId, dto, userId);
+
+        // Assert
+        result.Should().Be(MoveTaskResult.Success);
+        data!.TaskOrder.Should().Be(3);
+
+        var orders = await context.KanbanTasks
+            .AsNoTracking()
+            .Where(t => t.ColumnId == columnId)
+            .OrderBy(t => t.TaskOrder)
+            .Select(t => new { t.Title, t.TaskOrder })
+            .ToListAsync();
+
+        orders.Select(x => x.TaskOrder).Should().Equal(0, 1, 2, 3);
+        orders.Select(x => x.Title).Should().Equal("A", "C", "D", "B");
+    }
+
+    [Fact]
+    public async Task MoveTaskAsync_SameColumn_SamePosition_NoOp()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId, _) = await SeedProjectWithTwoColumnsAsync(context, userId);
+
+        var movedTaskId = Guid.NewGuid();
+        context.KanbanTasks.AddRange(
+            new KanbanTask { Id = Guid.NewGuid(), Title = "A", TaskOrder = 0, ColumnId = columnId },
+            new KanbanTask { Id = movedTaskId, Title = "B", TaskOrder = 1, ColumnId = columnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "C", TaskOrder = 2, ColumnId = columnId });
+        await context.SaveChangesAsync();
+
+        var dto = new MoveTaskDto { ColumnId = columnId, TaskOrder = 1 };
+
+        // Act
+        var (data, result) = await service.MoveTaskAsync(movedTaskId, dto, userId);
+
+        // Assert
+        result.Should().Be(MoveTaskResult.Success);
+        data!.TaskOrder.Should().Be(1);
+
+        var orders = await context.KanbanTasks
+            .AsNoTracking()
+            .Where(t => t.ColumnId == columnId)
+            .OrderBy(t => t.TaskOrder)
+            .Select(t => new { t.Title, t.TaskOrder })
+            .ToListAsync();
+
+        orders.Select(x => x.TaskOrder).Should().Equal(0, 1, 2);
+        orders.Select(x => x.Title).Should().Equal("A", "B", "C");
+    }
+
+    #endregion
+
+    #region Authorization & Not-Found Paths
+
+    [Fact]
+    public async Task MoveTaskAsync_TaskNotFound_ReturnsTaskNotFound()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId, _) = await SeedProjectWithTwoColumnsAsync(context, userId);
+
+        var dto = new MoveTaskDto { ColumnId = columnId, TaskOrder = 0 };
+
+        // Act
+        var (data, result) = await service.MoveTaskAsync(Guid.NewGuid(), dto, userId);
+
+        // Assert
+        result.Should().Be(MoveTaskResult.TaskNotFound);
+        data.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MoveTaskAsync_UserNotProjectMember_ReturnsUserNotProjectMember()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var memberId = Guid.NewGuid();
+        var outsiderId = Guid.NewGuid();
+        var (projectId, columnId, _) = await SeedProjectWithTwoColumnsAsync(context, memberId);
+
+        var taskId = Guid.NewGuid();
+        context.KanbanTasks.Add(new KanbanTask
+        {
+            Id = taskId,
+            Title = "T",
+            TaskOrder = 0,
+            ColumnId = columnId
+        });
+        await context.SaveChangesAsync();
+
+        var dto = new MoveTaskDto { ColumnId = columnId, TaskOrder = 0 };
+
+        // Act
+        var (data, result) = await service.MoveTaskAsync(taskId, dto, outsiderId);
+
+        // Assert
+        result.Should().Be(MoveTaskResult.UserNotProjectMember);
+        data.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MoveTaskAsync_TargetColumnNotFound_ReturnsTargetColumnNotFound()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId, _) = await SeedProjectWithTwoColumnsAsync(context, userId);
+
+        var taskId = Guid.NewGuid();
+        context.KanbanTasks.Add(new KanbanTask
+        {
+            Id = taskId,
+            Title = "T",
+            TaskOrder = 0,
+            ColumnId = columnId
+        });
+        await context.SaveChangesAsync();
+
+        var dto = new MoveTaskDto { ColumnId = Guid.NewGuid(), TaskOrder = 0 };
+
+        // Act
+        var (data, result) = await service.MoveTaskAsync(taskId, dto, userId);
+
+        // Assert
+        result.Should().Be(MoveTaskResult.TargetColumnNotFound);
+        data.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MoveTaskAsync_CrossProjectMove_ReturnsCrossProjectMove()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectAId, sourceColumnId, _) = await SeedProjectWithTwoColumnsAsync(context, userId);
+        var targetColumnInProjectB = await SeedSecondProjectWithColumnAsync(context, userId);
+
+        var taskId = Guid.NewGuid();
+        context.KanbanTasks.Add(new KanbanTask
+        {
+            Id = taskId,
+            Title = "T",
+            TaskOrder = 0,
+            ColumnId = sourceColumnId
+        });
+        await context.SaveChangesAsync();
+
+        var dto = new MoveTaskDto { ColumnId = targetColumnInProjectB, TaskOrder = 0 };
+
+        // Act
+        var (data, result) = await service.MoveTaskAsync(taskId, dto, userId);
+
+        // Assert
+        result.Should().Be(MoveTaskResult.CrossProjectMove);
+        data.Should().BeNull();
+    }
+
+    #endregion
+
+    #region TaskOrder Validation
+
+    [Fact]
+    public async Task MoveTaskAsync_InvalidTaskOrder_Negative_ReturnsInvalidTaskOrder()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId, _) = await SeedProjectWithTwoColumnsAsync(context, userId);
+
+        var taskId = Guid.NewGuid();
+        context.KanbanTasks.Add(new KanbanTask
+        {
+            Id = taskId,
+            Title = "T",
+            TaskOrder = 0,
+            ColumnId = columnId
+        });
+        await context.SaveChangesAsync();
+
+        var dto = new MoveTaskDto { ColumnId = columnId, TaskOrder = -1 };
+
+        // Act
+        var (data, result) = await service.MoveTaskAsync(taskId, dto, userId);
+
+        // Assert
+        result.Should().Be(MoveTaskResult.InvalidTaskOrder);
+        data.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MoveTaskAsync_InvalidTaskOrder_ExceedsTargetColumnCount_ReturnsInvalidTaskOrder()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, sourceColumnId, targetColumnId) = await SeedProjectWithTwoColumnsAsync(context, userId);
+
+        var movedTaskId = Guid.NewGuid();
+        context.KanbanTasks.AddRange(
+            new KanbanTask { Id = movedTaskId, Title = "M", TaskOrder = 0, ColumnId = sourceColumnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "X", TaskOrder = 0, ColumnId = targetColumnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "Y", TaskOrder = 1, ColumnId = targetColumnId });
+        await context.SaveChangesAsync();
+
+        // Target column has 2 tasks → valid TaskOrder is 0..2. TaskOrder=3 is invalid.
+        var dto = new MoveTaskDto { ColumnId = targetColumnId, TaskOrder = 3 };
+
+        // Act
+        var (data, result) = await service.MoveTaskAsync(movedTaskId, dto, userId);
+
+        // Assert
+        result.Should().Be(MoveTaskResult.InvalidTaskOrder);
+        data.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MoveTaskAsync_InvalidTaskOrder_ExceedsSameColumnCount_ReturnsInvalidTaskOrder()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, columnId, _) = await SeedProjectWithTwoColumnsAsync(context, userId);
+
+        var movedTaskId = Guid.NewGuid();
+        context.KanbanTasks.AddRange(
+            new KanbanTask { Id = movedTaskId, Title = "A", TaskOrder = 0, ColumnId = columnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "B", TaskOrder = 1, ColumnId = columnId },
+            new KanbanTask { Id = Guid.NewGuid(), Title = "C", TaskOrder = 2, ColumnId = columnId });
+        await context.SaveChangesAsync();
+
+        // Same-column reorder: 3 tasks → valid TaskOrder is 0..2. TaskOrder=3 is invalid.
+        var dto = new MoveTaskDto { ColumnId = columnId, TaskOrder = 3 };
+
+        // Act
+        var (data, result) = await service.MoveTaskAsync(movedTaskId, dto, userId);
+
+        // Assert
+        result.Should().Be(MoveTaskResult.InvalidTaskOrder);
+        data.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Sequential Invariant
+
+    [Fact]
+    public async Task MoveTaskAsync_MultipleSequentialMoves_MaintainsSequentialOrders()
+    {
+        // Arrange
+        var context = CreateInMemoryContext();
+        var service = new TaskService(context, _loggerMock.Object);
+        var userId = Guid.NewGuid();
+        var (projectId, sourceColumnId, targetColumnId) = await SeedProjectWithTwoColumnsAsync(context, userId);
+
+        var task1 = Guid.NewGuid();
+        var task2 = Guid.NewGuid();
+        var task3 = Guid.NewGuid();
+        context.KanbanTasks.AddRange(
+            new KanbanTask { Id = task1, Title = "A", TaskOrder = 0, ColumnId = sourceColumnId },
+            new KanbanTask { Id = task2, Title = "B", TaskOrder = 1, ColumnId = sourceColumnId },
+            new KanbanTask { Id = task3, Title = "C", TaskOrder = 2, ColumnId = sourceColumnId });
+        await context.SaveChangesAsync();
+
+        // Act — move three tasks across columns in sequence
+        var (_, result1) = await service.MoveTaskAsync(task2, new MoveTaskDto { ColumnId = targetColumnId, TaskOrder = 0 }, userId);
+        var (_, result2) = await service.MoveTaskAsync(task3, new MoveTaskDto { ColumnId = targetColumnId, TaskOrder = 0 }, userId);
+        var (_, result3) = await service.MoveTaskAsync(task1, new MoveTaskDto { ColumnId = targetColumnId, TaskOrder = 1 }, userId);
+
+        // Assert
+        result1.Should().Be(MoveTaskResult.Success);
+        result2.Should().Be(MoveTaskResult.Success);
+        result3.Should().Be(MoveTaskResult.Success);
+
+        var sourceOrders = await context.KanbanTasks
+            .AsNoTracking()
+            .Where(t => t.ColumnId == sourceColumnId)
+            .OrderBy(t => t.TaskOrder)
+            .Select(t => t.TaskOrder)
+            .ToListAsync();
+        sourceOrders.Should().BeEmpty();
+
+        var targetOrders = await context.KanbanTasks
+            .AsNoTracking()
+            .Where(t => t.ColumnId == targetColumnId)
+            .OrderBy(t => t.TaskOrder)
+            .Select(t => t.TaskOrder)
+            .ToListAsync();
+        targetOrders.Should().Equal(0, 1, 2);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static ApplicationDbContext CreateInMemoryContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+
+    private static async Task<(Guid projectId, Guid columnAId, Guid columnBId)> SeedProjectWithTwoColumnsAsync(
+        ApplicationDbContext context,
+        Guid memberUserId)
+    {
+        var projectId = Guid.NewGuid();
+        var project = new Project { Id = projectId, Name = "Test Project" };
+        context.Projects.Add(project);
+
+        context.Users.Add(new User
+        {
+            Id = memberUserId,
+            Name = "Member",
+            Email = $"{memberUserId}@example.com",
+            PasswordHash = "hash"
+        });
+
+        context.ProjectMembers.Add(new ProjectMember
+        {
+            ProjectId = projectId,
+            UserId = memberUserId,
+            Role = ProjectRole.Owner
+        });
+
+        var columnA = new BoardColumn
+        {
+            Id = Guid.NewGuid(),
+            Name = "To Do",
+            ColumnOrder = 0,
+            ProjectId = projectId
+        };
+        var columnB = new BoardColumn
+        {
+            Id = Guid.NewGuid(),
+            Name = "In Progress",
+            ColumnOrder = 1,
+            ProjectId = projectId
+        };
+        context.BoardColumns.AddRange(columnA, columnB);
+
+        await context.SaveChangesAsync();
+
+        return (projectId, columnA.Id, columnB.Id);
+    }
+
+    private static async Task<Guid> SeedSecondProjectWithColumnAsync(
+        ApplicationDbContext context,
+        Guid memberUserId)
+    {
+        var projectId = Guid.NewGuid();
+        var project = new Project { Id = projectId, Name = "Other Project" };
+        context.Projects.Add(project);
+
+        // Caller is a member of this second project too, so cross-project is the ONLY reason to fail.
+        context.ProjectMembers.Add(new ProjectMember
+        {
+            ProjectId = projectId,
+            UserId = memberUserId,
+            Role = ProjectRole.Owner
+        });
+
+        var column = new BoardColumn
+        {
+            Id = Guid.NewGuid(),
+            Name = "Other Column",
+            ColumnOrder = 0,
+            ProjectId = projectId
+        };
+        context.BoardColumns.Add(column);
+
+        await context.SaveChangesAsync();
+
+        return column.Id;
+    }
+
+    #endregion
+}

--- a/KanbAI-Core/KanbAI-Core/Controllers/TaskController.cs
+++ b/KanbAI-Core/KanbAI-Core/Controllers/TaskController.cs
@@ -50,6 +50,33 @@ public sealed class TaskController : ControllerBase
         };
     }
 
+    [HttpPut("{taskId}/move")]
+    public async Task<IActionResult> MoveTask(Guid taskId, [FromBody] MoveTaskDto dto)
+    {
+        var userId = GetCurrentUserId();
+
+        var (data, result) = await _taskService.MoveTaskAsync(taskId, dto, userId);
+
+        return result switch
+        {
+            MoveTaskResult.Success =>
+                Ok(ApiResponse<TaskResponseDto>.Ok(data!, "Task moved successfully.")),
+            MoveTaskResult.TaskNotFound =>
+                NotFound(ApiResponse.Fail("Task not found.")),
+            MoveTaskResult.UserNotProjectMember =>
+                StatusCode(StatusCodes.Status403Forbidden,
+                    ApiResponse.Fail("You are not a member of this project.")),
+            MoveTaskResult.TargetColumnNotFound =>
+                NotFound(ApiResponse.Fail("Target column not found.")),
+            MoveTaskResult.CrossProjectMove =>
+                BadRequest(ApiResponse.Fail("Cannot move task to a column in a different project.")),
+            MoveTaskResult.InvalidTaskOrder =>
+                BadRequest(ApiResponse.Fail("TaskOrder is invalid.")),
+            _ => StatusCode(StatusCodes.Status500InternalServerError,
+                     ApiResponse.Fail("Unexpected error."))
+        };
+    }
+
     private Guid GetCurrentUserId()
     {
         var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;

--- a/KanbAI-Core/KanbAI-Core/DTOs/MoveTaskDto.cs
+++ b/KanbAI-Core/KanbAI-Core/DTOs/MoveTaskDto.cs
@@ -1,0 +1,12 @@
+namespace KanbAI_Core.DTOs;
+
+using System.ComponentModel.DataAnnotations;
+
+public record MoveTaskDto
+{
+    [Required(ErrorMessage = "Target column ID is required.")]
+    public required Guid ColumnId { get; init; }
+
+    [Range(0, int.MaxValue, ErrorMessage = "Task order must be non-negative.")]
+    public required int TaskOrder { get; init; }
+}

--- a/KanbAI-Core/KanbAI-Core/Services/Tasks/ITaskService.cs
+++ b/KanbAI-Core/KanbAI-Core/Services/Tasks/ITaskService.cs
@@ -18,4 +18,25 @@ public interface ITaskService
         Guid columnId,
         CreateTaskDto dto,
         Guid userId);
+
+    /// <summary>
+    /// Moves a task to a new column and/or reorders it within its current column.
+    /// Authorization: the caller must be a member of the project that owns the task's current column.
+    /// Validation:
+    /// - Both the task's current column and the target column must belong to the same project.
+    /// - The new TaskOrder must be within the valid range:
+    ///   - If moving to a different column: 0 &lt;= TaskOrder &lt;= (target column task count)
+    ///   - If reordering within the same column: 0 &lt;= TaskOrder &lt;= (current column task count - 1)
+    /// Automatic recalculation:
+    /// - If moving to a different column: TaskOrder values in both source and target columns are recalculated to remove gaps.
+    /// - If reordering within the same column: TaskOrder values between the old and new positions are adjusted.
+    /// </summary>
+    /// <param name="taskId">The ID of the task to move.</param>
+    /// <param name="dto">Move operation data (target ColumnId and TaskOrder).</param>
+    /// <param name="userId">The authenticated user's ID (from JWT claims).</param>
+    /// <returns>A tuple containing the updated task (on success) and a <see cref="MoveTaskResult"/> discriminator.</returns>
+    Task<(TaskResponseDto? data, MoveTaskResult result)> MoveTaskAsync(
+        Guid taskId,
+        MoveTaskDto dto,
+        Guid userId);
 }

--- a/KanbAI-Core/KanbAI-Core/Services/Tasks/MoveTaskResult.cs
+++ b/KanbAI-Core/KanbAI-Core/Services/Tasks/MoveTaskResult.cs
@@ -1,0 +1,11 @@
+namespace KanbAI_Core.Services.Tasks;
+
+public enum MoveTaskResult
+{
+    Success,
+    TaskNotFound,
+    UserNotProjectMember,
+    TargetColumnNotFound,
+    CrossProjectMove,
+    InvalidTaskOrder
+}

--- a/KanbAI-Core/KanbAI-Core/Services/Tasks/TaskService.cs
+++ b/KanbAI-Core/KanbAI-Core/Services/Tasks/TaskService.cs
@@ -96,6 +96,165 @@ public sealed class TaskService : ITaskService
         return (MapToDto(task), CreateTaskResult.Success);
     }
 
+    public async Task<(TaskResponseDto? data, MoveTaskResult result)> MoveTaskAsync(
+        Guid taskId,
+        MoveTaskDto dto,
+        Guid userId)
+    {
+        if (dto.TaskOrder < 0)
+        {
+            _logger.LogWarning("Negative TaskOrder {TaskOrder} for task {TaskId}", dto.TaskOrder, taskId);
+            return (null, MoveTaskResult.InvalidTaskOrder);
+        }
+
+        var task = await _context.KanbanTasks
+            .Include(t => t.Column)
+                .ThenInclude(c => c.Project)
+                    .ThenInclude(p => p.Members)
+            .FirstOrDefaultAsync(t => t.Id == taskId);
+
+        if (task == null)
+        {
+            _logger.LogWarning("Task {TaskId} not found", taskId);
+            return (null, MoveTaskResult.TaskNotFound);
+        }
+
+        if (!task.Column.Project.Members.Any(m => m.UserId == userId))
+        {
+            _logger.LogWarning(
+                "User {UserId} attempted to move task {TaskId} without project membership",
+                userId, taskId);
+            return (null, MoveTaskResult.UserNotProjectMember);
+        }
+
+        var isSameColumn = dto.ColumnId == task.ColumnId;
+
+        if (!isSameColumn)
+        {
+            var targetColumn = await _context.BoardColumns
+                .Include(c => c.Project)
+                .FirstOrDefaultAsync(c => c.Id == dto.ColumnId);
+
+            if (targetColumn == null)
+            {
+                _logger.LogWarning("Target column {ColumnId} not found", dto.ColumnId);
+                return (null, MoveTaskResult.TargetColumnNotFound);
+            }
+
+            if (targetColumn.ProjectId != task.Column.ProjectId)
+            {
+                _logger.LogWarning(
+                    "User {UserId} attempted to move task {TaskId} to a column in a different project",
+                    userId, taskId);
+                return (null, MoveTaskResult.CrossProjectMove);
+            }
+        }
+
+        if (!isSameColumn)
+        {
+            var targetColumnTaskCount = await _context.KanbanTasks
+                .CountAsync(t => t.ColumnId == dto.ColumnId);
+
+            if (dto.TaskOrder > targetColumnTaskCount)
+            {
+                _logger.LogWarning(
+                    "Invalid TaskOrder {TaskOrder} for target column {ColumnId} with {Count} tasks",
+                    dto.TaskOrder, dto.ColumnId, targetColumnTaskCount);
+                return (null, MoveTaskResult.InvalidTaskOrder);
+            }
+        }
+        else
+        {
+            var currentColumnTaskCount = await _context.KanbanTasks
+                .CountAsync(t => t.ColumnId == task.ColumnId);
+
+            if (dto.TaskOrder > currentColumnTaskCount - 1)
+            {
+                _logger.LogWarning(
+                    "Invalid TaskOrder {TaskOrder} for same-column reorder with {Count} tasks",
+                    dto.TaskOrder, currentColumnTaskCount);
+                return (null, MoveTaskResult.InvalidTaskOrder);
+            }
+        }
+
+        if (isSameColumn && dto.TaskOrder == task.TaskOrder)
+        {
+            _logger.LogInformation(
+                "Task {TaskId} is already at position {TaskOrder} in column {ColumnId} - no changes needed",
+                taskId, dto.TaskOrder, dto.ColumnId);
+            return (MapToDto(task), MoveTaskResult.Success);
+        }
+
+        if (!isSameColumn)
+        {
+            var oldColumnId = task.ColumnId;
+            var oldTaskOrder = task.TaskOrder;
+
+            var sourceColumnTasks = await _context.KanbanTasks
+                .Where(t => t.ColumnId == oldColumnId && t.TaskOrder > oldTaskOrder)
+                .ToListAsync();
+
+            foreach (var t in sourceColumnTasks)
+            {
+                t.TaskOrder -= 1;
+            }
+
+            var targetColumnTasks = await _context.KanbanTasks
+                .Where(t => t.ColumnId == dto.ColumnId && t.TaskOrder >= dto.TaskOrder)
+                .ToListAsync();
+
+            foreach (var t in targetColumnTasks)
+            {
+                t.TaskOrder += 1;
+            }
+
+            task.ColumnId = dto.ColumnId;
+            task.TaskOrder = dto.TaskOrder;
+        }
+        else
+        {
+            var oldTaskOrder = task.TaskOrder;
+            var newTaskOrder = dto.TaskOrder;
+
+            if (newTaskOrder < oldTaskOrder)
+            {
+                var affectedTasks = await _context.KanbanTasks
+                    .Where(t => t.ColumnId == task.ColumnId
+                                && t.TaskOrder >= newTaskOrder
+                                && t.TaskOrder < oldTaskOrder)
+                    .ToListAsync();
+
+                foreach (var t in affectedTasks)
+                {
+                    t.TaskOrder += 1;
+                }
+            }
+            else
+            {
+                var affectedTasks = await _context.KanbanTasks
+                    .Where(t => t.ColumnId == task.ColumnId
+                                && t.TaskOrder > oldTaskOrder
+                                && t.TaskOrder <= newTaskOrder)
+                    .ToListAsync();
+
+                foreach (var t in affectedTasks)
+                {
+                    t.TaskOrder -= 1;
+                }
+            }
+
+            task.TaskOrder = newTaskOrder;
+        }
+
+        await _context.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "User {UserId} moved task {TaskId} to column {ColumnId} at order {TaskOrder}",
+            userId, taskId, task.ColumnId, task.TaskOrder);
+
+        return (MapToDto(task), MoveTaskResult.Success);
+    }
+
     private static TaskResponseDto MapToDto(KanbanTask task) =>
         new()
         {

--- a/docs/handoffs/issue_47_context.md
+++ b/docs/handoffs/issue_47_context.md
@@ -1,0 +1,282 @@
+# Issue #47: Implement Task Movement Logic (Drag-and-Drop Backend Support)
+
+**GitHub Issue:** [#47 - Implement Task Movement Logic (Drag-and-Drop Backend Support)](https://github.com/Gulybi/KanbAI-Core/issues/47)  
+**Milestone:** Project and Kanban Business Logic (Issue #47 of 2)  
+**Assignee:** @Gulybi  
+**Created:** 2026-04-27
+
+---
+
+## 📊 Business Value & Context
+
+### What Are We Building?
+A Task Movement API that enables users to reorder tasks within a single column or move tasks between different columns through drag-and-drop interactions. This includes:
+- **Moving tasks between columns** - Users can change a task's workflow stage by dragging it from one column (e.g., "To Do") to another (e.g., "In Progress")
+- **Reordering tasks within a column** - Users can prioritize work by changing the visual order of tasks in a column
+- **Automatic order recalculation** - When a task is moved, all affected tasks' TaskOrder values are automatically updated to maintain consistent, sequential ordering
+
+### Who Is This For?
+**Project Members** (anyone with access to a project) who need to:
+- Manage their workflow by moving tasks through stages (columns) as work progresses
+- Prioritize work by reordering tasks within the same column (moving urgent tasks to the top)
+- Visualize and control the flow of work across their Kanban board
+
+**Project Owners and Team Leads** benefit by:
+- Monitoring the flow of work across workflow stages in real-time
+- Identifying bottlenecks when too many tasks pile up in one column
+- Maintaining an accurate visual representation of work in progress
+
+### Why Is This Valuable?
+**Task movement is the core interaction** in a Kanban system. The three fundamental Kanban practices are:
+1. Visualize work
+2. Limit work in progress
+3. **Manage flow**
+
+Without task movement, users can create and view tasks, but they cannot update task status as work progresses or reprioritize work. The Kanban board becomes a static snapshot rather than a dynamic workflow management tool. This feature unlocks:
+- **Real workflow tracking** - Tasks move from "To Do" to "In Progress" to "Done" as work happens
+- **Dynamic prioritization** - Urgent tasks can be moved to the top of a column
+- **Accurate work-in-progress visualization** - The board reflects the current state of work, not a stale initial assignment
+
+---
+
+## 🗺️ Milestone Context
+
+**Milestone:** Project and Kanban Business Logic  
+**Total Issues:** 2 remaining in this milestone
+
+| Issue | Title | Status | Dependency |
+|-------|-------|--------|------------|
+| #44 | Implement Project Member Management | COMPLETED | Foundation for authorization |
+| #45 | Implement Board Columns API | COMPLETED | Provides columns for tasks to live in |
+| #46 | Implement Kanban Task Creation and Management | COMPLETED | Provides tasks that can be moved |
+| **#47** | **Implement Task Movement Logic (Drag-and-Drop Backend Support)** | **OPEN** | **← YOU ARE HERE** |
+
+**Prerequisites (Completed):**
+- Issue #44: Project Member Management exists, providing user-to-project relationships and authorization patterns
+- Issue #45: Board Columns API exists at `/api/Column/project/{projectId}` (GET, POST) and `/api/Column/{id}` (DELETE)
+- Issue #46: Task Creation API exists at POST `/api/Task/column/{columnId}`, creating tasks with automatic TaskOrder assignment
+
+**Relationship to Other Issues:**
+- **Depends on #46**: Tasks must exist before they can be moved. The task creation endpoint already demonstrates authorization patterns (project membership checks) and TaskOrder logic (automatic assignment at the bottom of a column).
+- **Completes the Milestone**: This is the final issue in the "Project and Kanban Business Logic" milestone. After this, users will have a fully functional Kanban board with CRUD operations for projects, columns, and tasks, plus the ability to move tasks across the board.
+
+---
+
+## 🔍 Current State vs. Desired State
+
+### Current State
+
+**Domain Model (Fully Implemented):**
+- `KanbanTask` entity exists in `KanbAI-Core/Models/Entities/KanbanTask.cs`:
+  - Properties:
+    - `Title` (string, required)
+    - `Content` (string, nullable)
+    - `TaskOrder` (int, required) - Determines the task's position within its column
+    - `ColumnId` (Guid, foreign key, required) - The board column this task belongs to
+    - `AssignedId` (Guid, nullable)
+  - Navigation properties:
+    - `Column` (BoardColumn) - The parent column
+    - `AssignedUser` (User, nullable)
+  - Inherits from `BaseEntity` (provides Id, CreatedAt, UpdatedAt)
+
+- `BoardColumn` entity exists in `KanbAI-Core/Models/Entities/BoardColumn.cs`:
+  - Properties: `Name`, `ColorCode`, `ColumnOrder`, `ProjectId`
+  - Navigation property `Tasks` (ICollection of KanbanTask)
+  - Inherits from `BaseEntity`
+
+**API Layer:**
+- `TaskController` exists in `KanbAI-Core/Controllers/TaskController.cs`:
+  - Single endpoint: POST `/api/Task/column/{columnId}` (create task)
+  - Authorization: [Authorize] attribute (JWT-based authentication)
+  - Helper: `GetCurrentUserId()` extracts authenticated user ID from JWT claims
+  - Response pattern: Uses `ApiResponse<T>` wrapper for standardized responses
+  - **No task movement endpoint exists**
+
+- `ColumnController` exists in `KanbAI-Core/Controllers/ColumnController.cs`:
+  - Endpoints: GET `/api/Column/project/{projectId}`, POST `/api/Column/project/{projectId}`, DELETE `/api/Column/{id}`
+  - Same authorization and response patterns as TaskController
+
+**Service Layer:**
+- `ITaskService` interface exists in `KanbAI-Core/Services/Tasks/ITaskService.cs`:
+  - Single method: `CreateTaskAsync(Guid columnId, CreateTaskDto dto, Guid userId)` returns `(TaskResponseDto? data, CreateTaskResult result)`
+  - **No method exists for moving tasks**
+
+- `TaskService` implementation exists in `KanbAI-Core/Services/Tasks/TaskService.cs`:
+  - Implements task creation with:
+    - Authorization: Verifies user is a member of the project that owns the target column
+    - Validation: Checks title is not empty, assigned user (if provided) is a project member
+    - Automatic TaskOrder assignment: Calculates `(max existing TaskOrder in column) + 1`, or 0 if column is empty
+  - Uses `CreateTaskResult` enum to communicate operation outcomes (Success, ColumnNotFound, UserNotProjectMember, InvalidTitle, etc.)
+
+**Data Transfer Objects:**
+- `CreateTaskDto` exists in `KanbAI-Core/DTOs/CreateTaskDto.cs`:
+  - Properties: `Title` (required, max 200 chars), `Content` (optional), `AssignedId` (optional)
+- `TaskResponseDto` exists in `KanbAI-Core/DTOs/TaskResponseDto.cs`:
+  - Properties: `Id`, `Title`, `Content`, `TaskOrder`, `ColumnId`, `AssignedId`, `CreatedAt`, `UpdatedAt`
+- **No DTO exists for task movement operations**
+
+**Authorization Pattern (Established):**
+- Task creation verifies that the user is a member of the project that owns the column
+- Pattern: Service layer queries `BoardColumn.Project.Members` to check for a matching `UserId`
+- Returns `CreateTaskResult.UserNotProjectMember` if user is not a member
+- Controller maps this to 403 Forbidden
+- This same pattern should be reused for task movement operations
+
+**TaskOrder Logic (Established):**
+- Task creation automatically sets `TaskOrder` to place new tasks at the bottom of a column
+- Calculation: `(max existing TaskOrder in column) + 1`, or 0 if no tasks exist
+- **No logic exists to recalculate TaskOrder values when a task is moved**
+
+### Desired State
+
+**API Layer:**
+- New endpoint in `TaskController`:
+  - **PUT `/api/Task/{taskId}/move`** - Move a task to a new column and/or reorder it within a column
+  - Accepts request body with `ColumnId` (new column, required) and `TaskOrder` (new position, required)
+  - Returns responses wrapped in the standard `ApiResponse<T>` format
+  - Protected with the `[Authorize]` attribute
+  - Reuses the `GetCurrentUserId()` pattern
+
+**Service Layer:**
+- New method in `ITaskService`:
+  - Move a task to a new column and/or position within its current column
+  - Automatically recalculate TaskOrder values for all affected tasks
+  - Verify user is a member of the project that owns both the source and target columns
+
+**Data Transfer Objects:**
+- New `MoveTaskDto` (or similar name) for task movement requests:
+  - `ColumnId` (Guid, required) - The new column to move the task to
+  - `TaskOrder` (int, required) - The new position within the column (0-based index)
+
+**Business Rules:**
+1. **Project membership required** - Only users who are members of the project can move tasks in that project's columns
+2. **Cross-column validation** - When moving a task from one column to another, both columns must belong to the same project
+3. **Automatic order recalculation** - When a task is moved:
+   - If moved to a different column: Remove gaps in the source column (decrement TaskOrder for tasks that were below the moved task), insert into target column at the specified position (increment TaskOrder for tasks at or below the insertion point)
+   - If reordered within the same column: Shift tasks between the old and new positions to accommodate the change
+4. **Position validation** - The new TaskOrder value must be within the valid range (0 to current task count in the target column)
+5. **Task existence** - The TaskId must reference an existing task
+6. **Column existence** - The new ColumnId must reference an existing column in the same project as the task's current column
+
+**Error Handling:**
+- 400 Bad Request: TaskOrder is out of range (negative or exceeds task count), ColumnId does not belong to the same project as the task's current column
+- 403 Forbidden: User is not a member of the project
+- 404 Not Found: Task does not exist, Column does not exist, or user is not a member of the project
+
+---
+
+## ✅ Acceptance Criteria
+
+**As a project member, I can move a task to a different column so that I can reflect workflow stage changes (e.g., move from "To Do" to "In Progress").**
+
+- [ ] A PUT `/api/Task/{taskId}/move` endpoint exists
+- [ ] The endpoint requires a valid JWT token (authenticated user)
+- [ ] The endpoint accepts a request body containing the new ColumnId and new TaskOrder
+- [ ] The endpoint returns 403 Forbidden if the authenticated user is not a member of the project that owns the task's current column
+- [ ] The endpoint returns 404 Not Found if the task does not exist
+- [ ] The endpoint returns 404 Not Found if the new column does not exist
+- [ ] The endpoint returns 400 Bad Request if the new column belongs to a different project than the task's current column
+- [ ] Upon successful move to a different column, the task's ColumnId is updated to the new column
+- [ ] Upon successful move to a different column, the task's TaskOrder is set to the specified value
+- [ ] The endpoint returns 200 OK with the updated task's details (id, title, taskOrder, columnId, createdAt, updatedAt)
+
+**Task order is automatically recalculated for affected tasks when a task is moved between columns.**
+
+- [ ] When a task is moved from column A to column B, all tasks in column A that were below the moved task have their TaskOrder decremented by 1 (to remove the gap left by the moved task)
+- [ ] When a task is moved to column B at position N, all tasks in column B at position N or higher have their TaskOrder incremented by 1 (to make room for the incoming task)
+- [ ] After the move, all tasks in both the source and target columns have sequential TaskOrder values with no gaps (0, 1, 2, 3, ...)
+- [ ] The recalculation happens atomically within a single database transaction
+
+**As a project member, I can reorder a task within the same column so that I can prioritize work.**
+
+- [ ] When the new ColumnId is the same as the task's current ColumnId, the task is reordered within the same column
+- [ ] If moving a task to a lower position (e.g., from position 5 to position 2), all tasks between the new and old positions have their TaskOrder incremented by 1
+- [ ] If moving a task to a higher position (e.g., from position 2 to position 5), all tasks between the old and new positions have their TaskOrder decremented by 1
+- [ ] After reordering, all tasks in the column have sequential TaskOrder values with no gaps
+- [ ] The reordering happens atomically within a single database transaction
+
+**Position validation ensures data integrity.**
+
+- [ ] If the new TaskOrder is negative, the endpoint returns 400 Bad Request with a clear error message (e.g., "TaskOrder cannot be negative.")
+- [ ] If the new TaskOrder exceeds the task count in the target column, the endpoint returns 400 Bad Request with a clear error message (e.g., "TaskOrder exceeds the number of tasks in the column.")
+- [ ] If moving to a different column, the valid TaskOrder range is 0 to (target column task count)
+- [ ] If reordering within the same column, the valid TaskOrder range is 0 to (current column task count - 1)
+
+**Authorization follows the established project membership pattern.**
+
+- [ ] Task movement verifies that the authenticated user is a member of the project that owns the task's current column
+- [ ] The authorization check uses the same pattern as TaskService.CreateTaskAsync (query `BoardColumn.Project.Members`)
+- [ ] If the user is not a member of the project, the endpoint returns 403 Forbidden
+- [ ] The error response uses the standard `ApiResponse.Fail()` pattern
+
+**The implementation follows existing architectural patterns.**
+
+- [ ] The move endpoint is added to the existing `TaskController` (no new controller needed)
+- [ ] The move method is added to the existing `ITaskService` interface
+- [ ] The move implementation is added to the existing `TaskService` class
+- [ ] A new DTO (e.g., MoveTaskDto) is created in the `KanbAI-Core/DTOs/` folder following the record pattern
+- [ ] All responses use the `ApiResponse<T>` wrapper for consistency
+- [ ] The service method returns a result enum (similar to `CreateTaskResult`) to communicate operation outcomes
+
+**Edge cases are handled gracefully.**
+
+- [ ] Attempting to move a non-existent task returns 404 Not Found
+- [ ] Attempting to move a task to a non-existent column returns 404 Not Found
+- [ ] Attempting to move a task to a column in a different project returns 400 Bad Request with a specific error message (e.g., "Cannot move task to a column in a different project.")
+- [ ] Attempting to move a task with an out-of-range TaskOrder returns 400 Bad Request with a specific error message
+- [ ] If the authenticated user's JWT is valid but they are not a member of the project, the endpoint returns 403 Forbidden (not 404)
+- [ ] Moving a task to its current position within its current column is a no-op (succeeds without side effects)
+
+---
+
+## 🎯 Out of Scope (Future Enhancements)
+
+These capabilities are explicitly **not** part of this issue and should be deferred to future work:
+
+- **Bulk task movement** - No ability to move multiple tasks in a single request
+- **Task history/audit log** - No record of task movements (who moved what task from where to where and when)
+- **Undo/redo functionality** - No way to revert a task movement
+- **Optimistic concurrency control** - No handling of simultaneous task movements by multiple users (last write wins)
+- **Drag-and-drop frontend implementation** - This issue only covers the backend API; frontend integration is a separate concern
+- **Column-level task count limits** - No enforcement of WIP (work-in-progress) limits per column
+- **Task movement notifications** - No real-time updates or notifications when tasks are moved by other users
+- **TaskOrder auto-adjustment on task deletion** - When a task is deleted, gaps remain in TaskOrder sequence (can be addressed separately)
+
+---
+
+## 📚 Reference Materials
+
+**Related Issues:**
+- [#44 - Implement Project Member Management](https://github.com/Gulybi/KanbAI-Core/issues/44) - Provides user-to-project relationships for authorization
+- [#45 - Implement Board Columns API](https://github.com/Gulybi/KanbAI-Core/issues/45) - Provides the columns that tasks belong to
+- [#46 - Implement Kanban Task Creation and Management](https://github.com/Gulybi/KanbAI-Core/issues/46) - Provides task creation with automatic TaskOrder assignment
+
+**Relevant Files:**
+- `KanbAI-Core/Models/Entities/KanbanTask.cs` - Task entity with Title, TaskOrder, ColumnId properties
+- `KanbAI-Core/Models/Entities/BoardColumn.cs` - Column entity with ProjectId and Tasks navigation property
+- `KanbAI-Core/Controllers/TaskController.cs` - Existing controller with task creation endpoint
+- `KanbAI-Core/Services/Tasks/ITaskService.cs` - Existing service interface to be extended
+- `KanbAI-Core/Services/Tasks/TaskService.cs` - Existing service implementation demonstrating authorization and TaskOrder logic
+- `KanbAI-Core/DTOs/TaskResponseDto.cs` - Existing DTO demonstrating the record pattern
+
+**Coding Standards:**
+- `.claude/rules/code-standards.md` - Modern C# conventions (file-scoped namespaces, async/await, DI patterns, EF Core optimizations)
+- `.claude/rules/security-safety.md` - Authorization checks, input validation, no PII in logs
+- `.claude/rules/testing-observability.md` - Unit test structure (AAA pattern), xUnit naming conventions
+
+---
+
+## 🚦 Success Metrics
+
+This feature is considered complete when:
+1. A project member can successfully move a task to a different column via the API with automatic TaskOrder recalculation for all affected tasks
+2. A project member can successfully reorder a task within the same column via the API with correct order shifts for affected tasks
+3. A non-project-member receives a 403 Forbidden when attempting to move a task in a project's columns
+4. All edge cases (out-of-range position, cross-project move attempt, non-existent task/column) return appropriate error codes and messages
+5. The implementation passes code review with zero concurrency issues (all database updates happen atomically within a transaction)
+6. Integration tests demonstrate the full workflow: create project, create columns, create multiple tasks, move task between columns, verify all TaskOrder values are sequential with no gaps
+
+---
+
+**Prepared by:** Product Manager Agent  
+**Date:** 2026-04-27

--- a/docs/handoffs/issue_47_tech_spec.md
+++ b/docs/handoffs/issue_47_tech_spec.md
@@ -1,0 +1,927 @@
+# Technical Specification: Issue #47 - Implement Task Movement Logic (Drag-and-Drop Backend Support)
+
+**GitHub Issue:** [#47 - Implement Task Movement Logic (Drag-and-Drop Backend Support)](https://github.com/Gulybi/KanbAI-Core/issues/47)
+**Context Document:** [issue_47_context.md](./issue_47_context.md)
+**Staff Engineer:** @agent_staff_engineer
+**Created:** 2026-04-27
+
+---
+
+## 1. Overview
+
+This specification defines the implementation of a Task Movement API that enables users to reorder tasks within a single column or move tasks between different columns through drag-and-drop interactions. The implementation extends the existing `TaskService` and `TaskController` (introduced in Issue #46) while leveraging the existing `KanbanTask` domain entity.
+
+**Scope:**
+- Extend `ITaskService` with a new `MoveTaskAsync` method
+- Extend `TaskController` with a new `PUT /api/Task/{taskId}/move` endpoint
+- Create one new DTO: `MoveTaskDto` (request)
+- Implement automatic TaskOrder recalculation for all affected tasks (same-column reorder or cross-column move)
+- Validate that both source and target columns belong to the same project
+- Reuse the existing project membership authorization pattern established in Issue #46
+
+**Out of Scope:**
+- No database schema changes, entity changes, or EF Core configuration changes. All required entities (`KanbanTask`, `BoardColumn`, `Project`, `ProjectMember`) and their configurations already exist.
+- No bulk task movement (moving multiple tasks in a single request)
+- No task history/audit log (deferred to future work)
+- No undo/redo functionality
+- No optimistic concurrency control (last write wins)
+- No column-level task count limits (WIP limits)
+- No task movement notifications or real-time updates
+
+**Why No Database Changes:**
+The `KanbanTask` entity already contains all required properties: `TaskOrder` (int), `ColumnId` (Guid foreign key). This issue is purely an application-layer/API addition that manipulates existing data.
+
+**Design Note - TaskOrder Recalculation:**
+This specification requires atomic, transactional updates to TaskOrder values across multiple tasks. All updates must occur within a single `SaveChangesAsync()` call to ensure consistency. The context note's Acceptance Criteria explicitly require that "all tasks in both the source and target columns have sequential TaskOrder values with no gaps (0, 1, 2, 3, ...)" after each move operation.
+
+---
+
+## 2. Database / Domain Design
+
+### 2.1 Existing Entities (No Changes Required)
+
+All required entities already exist. This section documents them for reference.
+
+#### KanbanTask Entity
+
+**File:** `KanbAI-Core/KanbAI-Core/Models/Entities/KanbanTask.cs`
+
+| Property | Type | Constraints | Source |
+|----------|------|-------------|--------|
+| `Id` | `Guid` | Primary key | Inherited from `BaseEntity` |
+| `Title` | `string` | Required, max 200 chars | Direct property |
+| `Content` | `string?` | Optional | Direct property |
+| `TaskOrder` | `int` | Required | Direct property |
+| `ColumnId` | `Guid` | Foreign key to `BoardColumn` (cascade) | Direct property |
+| `AssignedId` | `Guid?` | Foreign key to `User` (set null) | Direct property |
+| `CreatedAt` | `DateTimeOffset` | Auto-set on insert | Inherited from `BaseEntity` |
+| `UpdatedAt` | `DateTimeOffset` | Auto-updated on modify | Inherited from `BaseEntity` |
+| `Column` | `BoardColumn` | Navigation | — |
+| `AssignedUser` | `User?` | Navigation | — |
+
+**Key Property for This Issue:**
+- `TaskOrder` (int) - Determines the task's vertical position within its column. Values should be sequential (0, 1, 2, ...) with no gaps after any move operation.
+
+#### BoardColumn Entity
+
+**File:** `KanbAI-Core/KanbAI-Core/Models/Entities/BoardColumn.cs`
+
+| Property | Type | Constraints | Source |
+|----------|------|-------------|--------|
+| `Id` | `Guid` | Primary key | Inherited from `BaseEntity` |
+| `Name` | `string` | Required, max 100 chars | Direct property |
+| `ProjectId` | `Guid` | Foreign key to `Project` | Direct property |
+| `Project` | `Project` | Navigation | Cascade delete |
+| `Tasks` | `ICollection<KanbanTask>` | Navigation | Cascade delete |
+
+**Key Property for This Issue:**
+- `ProjectId` - Used to validate that both source and target columns belong to the same project (cross-project moves are not allowed).
+
+### 2.2 Expected Database Queries (EF Core)
+
+The service will execute the following queries:
+
+| Operation | Query Pattern | Purpose |
+|-----------|---------------|---------|
+| **Load task with column/project/members** | `SELECT * FROM KanbanTasks kt JOIN BoardColumns bc JOIN Projects p JOIN ProjectMembers pm WHERE kt.Id = @taskId` | Combined existence check + authorization + project membership in one round-trip |
+| **Load target column with project** | `SELECT * FROM BoardColumns bc JOIN Projects p WHERE bc.Id = @targetColumnId` | Validate target column exists and get ProjectId for cross-project check |
+| **Load affected tasks in source column** | `SELECT * FROM KanbanTasks WHERE ColumnId = @sourceColumnId AND TaskOrder > @oldOrder` | For cross-column moves: tasks below the moved task need TaskOrder decremented by 1 |
+| **Load affected tasks in target column** | `SELECT * FROM KanbanTasks WHERE ColumnId = @targetColumnId AND TaskOrder >= @newOrder` | For cross-column moves: tasks at or above insertion point need TaskOrder incremented by 1 |
+| **Load tasks between old and new positions (same column)** | `SELECT * FROM KanbanTasks WHERE ColumnId = @columnId AND TaskOrder BETWEEN @min AND @max` | For same-column reorder: tasks between old and new positions need TaskOrder adjusted |
+| **Update task ColumnId and TaskOrder** | `UPDATE KanbanTasks SET ColumnId = @newColumnId, TaskOrder = @newOrder WHERE Id = @taskId` | Move the task to its new location |
+| **Bulk update TaskOrder values** | Multiple `UPDATE KanbanTasks SET TaskOrder = @newValue WHERE Id = @id` | Recalculate order for all affected tasks (EF Core will batch these in `SaveChangesAsync()`) |
+
+**N+1 Prevention:**
+- Initial task load uses `.Include(t => t.Column).ThenInclude(c => c.Project).ThenInclude(p => p.Members)` to load task, column, project, and members in a single query.
+- Target column load uses `.Include(c => c.Project)` for cross-project validation.
+
+**Read Optimization:**
+- The initial task load and target column load are **tracked** queries (no `.AsNoTracking()`) because we will mutate the task entity (change `ColumnId` and `TaskOrder`).
+- Queries for affected tasks in source/target columns are also tracked so EF Core can track TaskOrder changes.
+
+**Transaction Semantics:**
+All TaskOrder updates (source column, target column, and the moved task itself) must occur within a single `SaveChangesAsync()` call to ensure atomicity. EF Core's change tracker will manage this automatically - no explicit transaction block required.
+
+---
+
+## 3. API Contracts
+
+### 3.1 Endpoint Summary
+
+| Method | Route | Auth | Request Body | Response DTO | Success | Failure |
+|--------|-------|------|--------------|--------------|---------|---------|
+| PUT | `/api/Task/{taskId}/move` | Required | `MoveTaskDto` | `ApiResponse<TaskResponseDto>` | 200 OK | 400, 401, 403, 404 |
+
+### 3.2 DTO Definitions
+
+#### MoveTaskDto (Request)
+
+**File:** `KanbAI-Core/KanbAI-Core/DTOs/MoveTaskDto.cs`
+
+```csharp
+namespace KanbAI_Core.DTOs;
+
+using System.ComponentModel.DataAnnotations;
+
+public record MoveTaskDto
+{
+    [Required(ErrorMessage = "Target column ID is required.")]
+    public required Guid ColumnId { get; init; }
+
+    [Range(0, int.MaxValue, ErrorMessage = "Task order must be non-negative.")]
+    public required int TaskOrder { get; init; }
+}
+```
+
+**Validation Rules:**
+- `ColumnId`: Required (the new column to move the task to; can be the same as the current column for reordering)
+- `TaskOrder`: Required, must be >= 0 (the new position within the target column; 0-based index)
+- **Additional service-layer validation:** `TaskOrder` must be within the valid range:
+  - If moving to a different column: `0 <= TaskOrder <= (target column task count)`
+  - If reordering within the same column: `0 <= TaskOrder <= (current column task count - 1)`
+
+**Note:** We intentionally do NOT validate the upper bound at the DTO level because it requires database access. The service layer will perform this check.
+
+### 3.3 Example API Interactions
+
+#### Example 1 - Move Task to Different Column (Success)
+
+**Scenario:** Task is currently in column A at position 2 (TaskOrder=2). We move it to column B at position 1 (TaskOrder=1).
+
+**Request:**
+```http
+PUT /api/Task/a1b2c3d4-e5f6-7890-abcd-ef1234567890/move HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
+Content-Type: application/json
+
+{
+  "columnId": "c5d6e7f8-g9h0-i1j2-k3l4-m5n6o7p8q9r0",
+  "taskOrder": 1
+}
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Task moved successfully.",
+  "data": {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "title": "Implement login API",
+    "content": "Add JWT authentication endpoint",
+    "taskOrder": 1,
+    "columnId": "c5d6e7f8-g9h0-i1j2-k3l4-m5n6o7p8q9r0",
+    "assignedId": "77777777-7777-7777-7777-777777777777",
+    "createdAt": "2026-04-27T10:00:00Z",
+    "updatedAt": "2026-04-27T14:30:00Z"
+  },
+  "errors": []
+}
+```
+
+#### Example 2 - Reorder Task Within Same Column (Success)
+
+**Scenario:** Task is currently at position 5 in column A. We move it to position 2 in the same column (prioritize it).
+
+**Request:**
+```http
+PUT /api/Task/a1b2c3d4-e5f6-7890-abcd-ef1234567890/move HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
+Content-Type: application/json
+
+{
+  "columnId": "c1a2b3c4-5d6e-7f8g-9h0i-1j2k3l4m5n6o",
+  "taskOrder": 2
+}
+```
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "message": "Task moved successfully.",
+  "data": {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "title": "Implement login API",
+    "content": "Add JWT authentication endpoint",
+    "taskOrder": 2,
+    "columnId": "c1a2b3c4-5d6e-7f8g-9h0i-1j2k3l4m5n6o",
+    "assignedId": null,
+    "createdAt": "2026-04-27T10:00:00Z",
+    "updatedAt": "2026-04-27T14:35:00Z"
+  },
+  "errors": []
+}
+```
+
+#### Example 3 - Invalid TaskOrder (Out of Range)
+
+**Scenario:** Target column has 3 tasks (TaskOrder 0, 1, 2). User tries to move a task from another column to position 5.
+
+**Request:**
+```http
+PUT /api/Task/a1b2c3d4-e5f6-7890-abcd-ef1234567890/move HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
+Content-Type: application/json
+
+{
+  "columnId": "c5d6e7f8-g9h0-i1j2-k3l4-m5n6o7p8q9r0",
+  "taskOrder": 5
+}
+```
+
+**Response (400 Bad Request):**
+```json
+{
+  "success": false,
+  "message": "TaskOrder exceeds the number of tasks in the target column.",
+  "errors": []
+}
+```
+
+#### Example 4 - Negative TaskOrder
+
+**Request:**
+```http
+PUT /api/Task/a1b2c3d4-e5f6-7890-abcd-ef1234567890/move HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
+Content-Type: application/json
+
+{
+  "columnId": "c5d6e7f8-g9h0-i1j2-k3l4-m5n6o7p8q9r0",
+  "taskOrder": -1
+}
+```
+
+**Response (400 Bad Request):**
+```json
+{
+  "success": false,
+  "message": "TaskOrder cannot be negative.",
+  "errors": []
+}
+```
+
+#### Example 5 - Cross-Project Move Attempt
+
+**Scenario:** Task is in column A (project X). User tries to move it to column B (project Y).
+
+**Request:**
+```http
+PUT /api/Task/a1b2c3d4-e5f6-7890-abcd-ef1234567890/move HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
+Content-Type: application/json
+
+{
+  "columnId": "z9y8x7w6-5v4u-3t2s-1r0q-p9o8n7m6l5k4",
+  "taskOrder": 0
+}
+```
+
+**Response (400 Bad Request):**
+```json
+{
+  "success": false,
+  "message": "Cannot move task to a column in a different project.",
+  "errors": []
+}
+```
+
+#### Example 6 - Task Not Found
+
+**Request:**
+```http
+PUT /api/Task/00000000-0000-0000-0000-000000000000/move HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
+Content-Type: application/json
+
+{
+  "columnId": "c5d6e7f8-g9h0-i1j2-k3l4-m5n6o7p8q9r0",
+  "taskOrder": 0
+}
+```
+
+**Response (404 Not Found):**
+```json
+{
+  "success": false,
+  "message": "Task not found.",
+  "errors": []
+}
+```
+
+#### Example 7 - User Not a Project Member
+
+**Scenario:** User is authenticated but not a member of the project that owns the task's current column.
+
+**Response (403 Forbidden):**
+```json
+{
+  "success": false,
+  "message": "You are not a member of this project.",
+  "errors": []
+}
+```
+
+#### Example 8 - Target Column Not Found
+
+**Request:**
+```http
+PUT /api/Task/a1b2c3d4-e5f6-7890-abcd-ef1234567890/move HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
+Content-Type: application/json
+
+{
+  "columnId": "00000000-0000-0000-0000-000000000000",
+  "taskOrder": 0
+}
+```
+
+**Response (404 Not Found):**
+```json
+{
+  "success": false,
+  "message": "Target column not found.",
+  "errors": []
+}
+```
+
+---
+
+## 4. Application Layer Boundaries
+
+### 4.1 Result Discriminator Enum (Extension)
+
+Extend the existing `CreateTaskResult` enum to support the move operation. Because task movement has distinct failure modes (invalid TaskOrder range, cross-project move, target column not found), we need a new discriminator enum.
+
+**File:** `KanbAI-Core/KanbAI-Core/Services/Tasks/MoveTaskResult.cs` (NEW)
+
+```csharp
+namespace KanbAI_Core.Services.Tasks;
+
+public enum MoveTaskResult
+{
+    Success,
+    TaskNotFound,
+    UserNotProjectMember,
+    TargetColumnNotFound,
+    CrossProjectMove,
+    InvalidTaskOrder
+}
+```
+
+### 4.2 ITaskService Interface (Extension)
+
+**File:** `KanbAI-Core/KanbAI-Core/Services/Tasks/ITaskService.cs` (EXTEND)
+
+Add the following method to the existing interface:
+
+```csharp
+/// <summary>
+/// Moves a task to a new column and/or reorders it within its current column.
+/// Authorization: the caller must be a member of the project that owns the task's current column.
+/// Validation:
+/// - Both the task's current column and the target column must belong to the same project.
+/// - The new TaskOrder must be within the valid range:
+///   - If moving to a different column: 0 <= TaskOrder <= (target column task count)
+///   - If reordering within the same column: 0 <= TaskOrder <= (current column task count - 1)
+/// Automatic recalculation:
+/// - If moving to a different column: TaskOrder values in both source and target columns are recalculated to remove gaps.
+/// - If reordering within the same column: TaskOrder values between the old and new positions are adjusted.
+/// </summary>
+/// <param name="taskId">The ID of the task to move.</param>
+/// <param name="dto">Move operation data (target ColumnId and TaskOrder).</param>
+/// <param name="userId">The authenticated user's ID (from JWT claims).</param>
+/// <returns>A tuple containing the updated task (on success) and a <see cref="MoveTaskResult"/> discriminator.</returns>
+Task<(TaskResponseDto? data, MoveTaskResult result)> MoveTaskAsync(
+    Guid taskId,
+    MoveTaskDto dto,
+    Guid userId);
+```
+
+### 4.3 TaskService Implementation (Extension)
+
+**File:** `KanbAI-Core/KanbAI-Core/Services/Tasks/TaskService.cs` (EXTEND)
+
+Add the `MoveTaskAsync` method to the existing `TaskService` class.
+
+**Key Algorithm:**
+
+1. **Validation - Negative TaskOrder:**
+   ```csharp
+   if (dto.TaskOrder < 0)
+       return (null, MoveTaskResult.InvalidTaskOrder);
+   ```
+
+2. **Load task with column, project, and members:**
+   ```csharp
+   var task = await _context.KanbanTasks
+       .Include(t => t.Column)
+           .ThenInclude(c => c.Project)
+               .ThenInclude(p => p.Members)
+       .FirstOrDefaultAsync(t => t.Id == taskId);
+   
+   if (task == null)
+   {
+       _logger.LogWarning("Task {TaskId} not found", taskId);
+       return (null, MoveTaskResult.TaskNotFound);
+   }
+   ```
+
+3. **Authorization check:**
+   ```csharp
+   var isMember = task.Column.Project.Members.Any(m => m.UserId == userId);
+   if (!isMember)
+   {
+       _logger.LogWarning("User {UserId} attempted to move task {TaskId} without project membership", userId, taskId);
+       return (null, MoveTaskResult.UserNotProjectMember);
+   }
+   ```
+
+4. **Load target column (if different from current column):**
+   ```csharp
+   BoardColumn targetColumn;
+   if (dto.ColumnId != task.ColumnId)
+   {
+       targetColumn = await _context.BoardColumns
+           .Include(c => c.Project)
+           .FirstOrDefaultAsync(c => c.Id == dto.ColumnId);
+       
+       if (targetColumn == null)
+       {
+           _logger.LogWarning("Target column {ColumnId} not found", dto.ColumnId);
+           return (null, MoveTaskResult.TargetColumnNotFound);
+       }
+       
+       // Cross-project check
+       if (targetColumn.ProjectId != task.Column.ProjectId)
+       {
+           _logger.LogWarning("User {UserId} attempted to move task {TaskId} to a column in a different project", userId, taskId);
+           return (null, MoveTaskResult.CrossProjectMove);
+       }
+   }
+   else
+   {
+       targetColumn = task.Column; // Same column - reorder only
+   }
+   ```
+
+5. **Validate TaskOrder range:**
+   ```csharp
+   int targetColumnTaskCount;
+   if (dto.ColumnId != task.ColumnId)
+   {
+       // Moving to different column: max TaskOrder is (task count in target column)
+       targetColumnTaskCount = await _context.KanbanTasks
+           .CountAsync(t => t.ColumnId == dto.ColumnId);
+       
+       if (dto.TaskOrder > targetColumnTaskCount)
+       {
+           _logger.LogWarning("Invalid TaskOrder {TaskOrder} for target column {ColumnId} with {Count} tasks", 
+               dto.TaskOrder, dto.ColumnId, targetColumnTaskCount);
+           return (null, MoveTaskResult.InvalidTaskOrder);
+       }
+   }
+   else
+   {
+       // Reordering within same column: max TaskOrder is (task count - 1)
+       targetColumnTaskCount = await _context.KanbanTasks
+           .CountAsync(t => t.ColumnId == task.ColumnId);
+       
+       if (dto.TaskOrder > targetColumnTaskCount - 1)
+       {
+           _logger.LogWarning("Invalid TaskOrder {TaskOrder} for same-column reorder with {Count} tasks", 
+               dto.TaskOrder, targetColumnTaskCount);
+           return (null, MoveTaskResult.InvalidTaskOrder);
+       }
+   }
+   ```
+
+6. **No-op check (moving to same position):**
+   ```csharp
+   if (dto.ColumnId == task.ColumnId && dto.TaskOrder == task.TaskOrder)
+   {
+       // No-op: task is already at the target position
+       _logger.LogInformation("Task {TaskId} is already at position {TaskOrder} in column {ColumnId} - no changes needed", 
+           taskId, dto.TaskOrder, dto.ColumnId);
+       return (MapToDto(task), MoveTaskResult.Success);
+   }
+   ```
+
+7. **Recalculate TaskOrder values:**
+
+   **Case A: Moving to a different column**
+   ```csharp
+   if (dto.ColumnId != task.ColumnId)
+   {
+       var oldColumnId = task.ColumnId;
+       var oldTaskOrder = task.TaskOrder;
+       
+       // 1. Decrement TaskOrder for tasks in source column that were below the moved task
+       var sourceColumnTasks = await _context.KanbanTasks
+           .Where(t => t.ColumnId == oldColumnId && t.TaskOrder > oldTaskOrder)
+           .ToListAsync();
+       
+       foreach (var t in sourceColumnTasks)
+       {
+           t.TaskOrder -= 1;
+       }
+       
+       // 2. Increment TaskOrder for tasks in target column at or above the insertion point
+       var targetColumnTasks = await _context.KanbanTasks
+           .Where(t => t.ColumnId == dto.ColumnId && t.TaskOrder >= dto.TaskOrder)
+           .ToListAsync();
+       
+       foreach (var t in targetColumnTasks)
+       {
+           t.TaskOrder += 1;
+       }
+       
+       // 3. Update the moved task
+       task.ColumnId = dto.ColumnId;
+       task.TaskOrder = dto.TaskOrder;
+   }
+   ```
+
+   **Case B: Reordering within the same column**
+   ```csharp
+   else
+   {
+       var oldTaskOrder = task.TaskOrder;
+       var newTaskOrder = dto.TaskOrder;
+       
+       if (newTaskOrder < oldTaskOrder)
+       {
+           // Moving up (e.g., from position 5 to position 2)
+           // Tasks between newTaskOrder and oldTaskOrder need TaskOrder incremented by 1
+           var affectedTasks = await _context.KanbanTasks
+               .Where(t => t.ColumnId == task.ColumnId && t.TaskOrder >= newTaskOrder && t.TaskOrder < oldTaskOrder)
+               .ToListAsync();
+           
+           foreach (var t in affectedTasks)
+           {
+               t.TaskOrder += 1;
+           }
+       }
+       else
+       {
+           // Moving down (e.g., from position 2 to position 5)
+           // Tasks between oldTaskOrder and newTaskOrder need TaskOrder decremented by 1
+           var affectedTasks = await _context.KanbanTasks
+               .Where(t => t.ColumnId == task.ColumnId && t.TaskOrder > oldTaskOrder && t.TaskOrder <= newTaskOrder)
+               .ToListAsync();
+           
+           foreach (var t in affectedTasks)
+           {
+               t.TaskOrder -= 1;
+           }
+       }
+       
+       // Update the moved task
+       task.TaskOrder = newTaskOrder;
+   }
+   ```
+
+8. **Save changes and return:**
+   ```csharp
+   await _context.SaveChangesAsync();
+   
+   _logger.LogInformation("User {UserId} moved task {TaskId} to column {ColumnId} at order {TaskOrder}", 
+       userId, taskId, task.ColumnId, task.TaskOrder);
+   
+   return (MapToDto(task), MoveTaskResult.Success);
+   ```
+
+**Note:** The existing `MapToDto` method can be reused (no changes needed).
+
+### 4.4 TaskController (Extension)
+
+**File:** `KanbAI-Core/KanbAI-Core/Controllers/TaskController.cs` (EXTEND)
+
+Add the following endpoint to the existing `TaskController`:
+
+```csharp
+[HttpPut("{taskId}/move")]
+public async Task<IActionResult> MoveTask(Guid taskId, [FromBody] MoveTaskDto dto)
+{
+    var userId = GetCurrentUserId();
+
+    var (data, result) = await _taskService.MoveTaskAsync(taskId, dto, userId);
+
+    return result switch
+    {
+        MoveTaskResult.Success =>
+            Ok(ApiResponse<TaskResponseDto>.Ok(data!, "Task moved successfully.")),
+        MoveTaskResult.TaskNotFound =>
+            NotFound(ApiResponse.Fail("Task not found.")),
+        MoveTaskResult.UserNotProjectMember =>
+            StatusCode(StatusCodes.Status403Forbidden,
+                ApiResponse.Fail("You are not a member of this project.")),
+        MoveTaskResult.TargetColumnNotFound =>
+            NotFound(ApiResponse.Fail("Target column not found.")),
+        MoveTaskResult.CrossProjectMove =>
+            BadRequest(ApiResponse.Fail("Cannot move task to a column in a different project.")),
+        MoveTaskResult.InvalidTaskOrder =>
+            BadRequest(ApiResponse.Fail("TaskOrder is invalid.")),
+        _ => StatusCode(StatusCodes.Status500InternalServerError,
+                 ApiResponse.Fail("Unexpected error."))
+    };
+}
+```
+
+**Note:** The endpoint reuses the existing `GetCurrentUserId()` helper method (no changes needed).
+
+---
+
+## 5. Implementation Steps for @agent_developer
+
+### Step 1 - Create the MoveTaskDto
+
+**File:** `KanbAI-Core/KanbAI-Core/DTOs/MoveTaskDto.cs`
+
+Create the new DTO using the exact code from Section 3.2.
+
+### Step 2 - Create the MoveTaskResult Enum
+
+**File:** `KanbAI-Core/KanbAI-Core/Services/Tasks/MoveTaskResult.cs`
+
+Create the new enum using the exact code from Section 4.1.
+
+### Step 3 - Extend ITaskService Interface
+
+**File:** `KanbAI-Core/KanbAI-Core/Services/Tasks/ITaskService.cs`
+
+Add the `MoveTaskAsync` method signature from Section 4.2. The file will now contain two methods: `CreateTaskAsync` (existing) and `MoveTaskAsync` (new).
+
+### Step 4 - Implement MoveTaskAsync in TaskService
+
+**File:** `KanbAI-Core/KanbAI-Core/Services/Tasks/TaskService.cs`
+
+Add the `MoveTaskAsync` method to the existing `TaskService` class. Follow the algorithm in Section 4.3 exactly. The method should be approximately 150-200 lines long (including comments and logging).
+
+**Key Implementation Points:**
+- All TaskOrder updates must happen within the same database context before calling `SaveChangesAsync()` (ensures atomicity).
+- Use structured logging (parameterized templates, no string interpolation).
+- Reuse the existing `MapToDto` method (no changes needed).
+- Follow the existing code style in `CreateTaskAsync` (same logging patterns, same navigation property loading patterns).
+
+### Step 5 - Extend TaskController with MoveTask Endpoint
+
+**File:** `KanbAI-Core/KanbAI-Core/Controllers/TaskController.cs`
+
+Add the `MoveTask` endpoint from Section 4.4. The controller will now have two endpoints: `CreateTask` (existing, POST) and `MoveTask` (new, PUT).
+
+### Step 6 - Build & Verify
+
+```bash
+cd KanbAI-Core/KanbAI-Core
+dotnet build --no-incremental
+```
+
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`.
+
+### Step 7 - Smoke Run (Optional)
+
+Run the app (`dotnet run`), open Scalar UI, authenticate, and manually test the move endpoint:
+1. Create a project, columns, and tasks
+2. Move a task to a different column
+3. Verify TaskOrder values are sequential in both columns
+4. Reorder a task within the same column
+5. Verify TaskOrder values adjust correctly
+
+---
+
+## 6. QA Guidance for @agent_tester_qa
+
+### 6.1 Test File Locations
+
+| Test File | Location | Type | Purpose |
+|-----------|----------|------|---------|
+| `TaskServiceMoveTests.cs` | `KanbAI-Core.Tests/Services/Tasks/` | Unit | Business logic for move operations with EF Core in-memory DbContext |
+| `TaskControllerMoveTests.cs` | `KanbAI-Core.Tests/Controllers/` | Unit | HTTP response mapping for move endpoint; DTO-level validation |
+| `TaskMoveApiIntegrationTests.cs` | `KanbAI-Core.Tests/Integration/` | Integration | HTTP-level auth + validation for move endpoint |
+
+### 6.2 Test Case Tables
+
+#### TaskServiceMoveTests.cs (Unit)
+
+| # | Test Name | Category | Description |
+|---|-----------|----------|-------------|
+| 1 | `MoveTaskAsync_DifferentColumn_UpdatesColumnIdAndTaskOrder` | Cross-column | Move task from column A to column B; verify task.ColumnId and task.TaskOrder updated |
+| 2 | `MoveTaskAsync_DifferentColumn_RecalculatesSourceColumnOrders` | Cross-column | After moving task from position 2 (column A with 5 tasks), verify remaining tasks have TaskOrder 0,1,2,3 (no gap) |
+| 3 | `MoveTaskAsync_DifferentColumn_RecalculatesTargetColumnOrders` | Cross-column | After moving task to position 1 (column B with 3 tasks), verify target column tasks have TaskOrder 0,1,2,3 (new task at 1, old tasks shifted) |
+| 4 | `MoveTaskAsync_SameColumn_MoveUp_RecalculatesOrders` | Same-column | Move task from position 5 to position 2; verify tasks at 2,3,4 shift to 3,4,5 |
+| 5 | `MoveTaskAsync_SameColumn_MoveDown_RecalculatesOrders` | Same-column | Move task from position 2 to position 5; verify tasks at 3,4,5 shift to 2,3,4 |
+| 6 | `MoveTaskAsync_SameColumn_SamePosition_NoOp` | Same-column | Move task to its current position; verify no TaskOrder changes, returns Success |
+| 7 | `MoveTaskAsync_TaskNotFound_ReturnsTaskNotFound` | 404 path | Random Guid for taskId |
+| 8 | `MoveTaskAsync_UserNotProjectMember_ReturnsUserNotProjectMember` | 403 path | User not in project |
+| 9 | `MoveTaskAsync_TargetColumnNotFound_ReturnsTargetColumnNotFound` | 404 path | Random Guid for target ColumnId |
+| 10 | `MoveTaskAsync_CrossProjectMove_ReturnsCrossProjectMove` | 400 path | Task in project A, target column in project B |
+| 11 | `MoveTaskAsync_InvalidTaskOrder_Negative_ReturnsInvalidTaskOrder` | Validation | TaskOrder = -1 |
+| 12 | `MoveTaskAsync_InvalidTaskOrder_ExceedsTargetColumnCount_ReturnsInvalidTaskOrder` | Validation | TaskOrder = (target column task count + 1) |
+| 13 | `MoveTaskAsync_InvalidTaskOrder_ExceedsSameColumnCount_ReturnsInvalidTaskOrder` | Validation | Same-column move, TaskOrder = (column task count) |
+| 14 | `MoveTaskAsync_MultipleSequentialMoves_MaintainsSequentialOrders` | Ordering | Move task A, then task B, verify all TaskOrder values remain sequential |
+
+#### TaskControllerMoveTests.cs (Unit - mocked service)
+
+| # | Test Name | Category | Description |
+|---|-----------|----------|-------------|
+| 15 | `MoveTask_ServiceReturnsSuccess_Returns200OK` | HTTP | 200 + ApiResponse.Ok with updated TaskResponseDto |
+| 16 | `MoveTask_ServiceReturnsTaskNotFound_Returns404` | HTTP | NotFound + ApiResponse.Fail("Task not found.") |
+| 17 | `MoveTask_ServiceReturnsUserNotProjectMember_Returns403` | HTTP | StatusCode(403) + ApiResponse.Fail(...) |
+| 18 | `MoveTask_ServiceReturnsTargetColumnNotFound_Returns404` | HTTP | NotFound body matches spec |
+| 19 | `MoveTask_ServiceReturnsCrossProjectMove_Returns400` | HTTP | BadRequest with "Cannot move task to a column in a different project." |
+| 20 | `MoveTask_ServiceReturnsInvalidTaskOrder_Returns400` | HTTP | BadRequest with "TaskOrder is invalid." |
+| 21 | `MoveTask_MissingColumnId_FailsDataAnnotationsValidation` | Validation | Validator.TryValidateObject rejects missing required field |
+| 22 | `MoveTask_NegativeTaskOrder_FailsDataAnnotationsValidation` | Validation | [Range(0, int.MaxValue)] rejects -1 |
+
+#### TaskMoveApiIntegrationTests.cs (Integration)
+
+| # | Test Name | Category | Description |
+|---|-----------|----------|-------------|
+| 23 | `PutMoveTask_Unauthenticated_Returns401` | Security | [Authorize] enforcement |
+| 24 | `PutMoveTask_MissingColumnId_Returns400` | Validation | [ApiController] rejects missing required field |
+| 25 | `PutMoveTask_NegativeTaskOrder_Returns400` | Validation | [Range(0, int.MaxValue)] enforced |
+
+### 6.3 Test Infrastructure
+
+- **Unit tests (service):** EF Core In-Memory provider. Seed `Project`, `ProjectMember`, `BoardColumn` (2+ columns in same project), and `KanbanTask` rows (3+ tasks per column) in `Arrange`. Use `Guid.NewGuid()` for all keys.
+- **Unit tests (controller):** Mock `ITaskService`, construct `ClaimsPrincipal` with `NameIdentifier` claim, assign via `ControllerContext`.
+- **Integration tests:** Follow `integration-testing.md` pattern (TestAuthHandler, remove Negotiate auth, set FallbackPolicy = null).
+- **Naming:** strictly `MethodName_StateUnderTest_ExpectedBehavior`.
+- **AAA layout:** blank lines between Arrange/Act/Assert.
+
+### 6.4 Key Test Scenarios for QA
+
+**Scenario 1: Cross-Column Move with TaskOrder Recalculation**
+- Setup: Column A has tasks [0: "A", 1: "B", 2: "C", 3: "D"]. Column B has tasks [0: "X", 1: "Y"].
+- Action: Move task "C" (currently at A[2]) to column B at position 1.
+- Verify:
+  - Column A tasks are now [0: "A", 1: "B", 2: "D"] (no gap at position 2).
+  - Column B tasks are now [0: "X", 1: "C", 2: "Y"].
+  - Task "C" has ColumnId = B, TaskOrder = 1.
+
+**Scenario 2: Same-Column Reorder (Move Up)**
+- Setup: Column A has tasks [0: "A", 1: "B", 2: "C", 3: "D", 4: "E", 5: "F"].
+- Action: Move task "E" (currently at position 4) to position 1.
+- Verify:
+  - Column A tasks are now [0: "A", 1: "E", 2: "B", 3: "C", 4: "D", 5: "F"].
+  - Tasks "B", "C", "D" shifted from [1,2,3] to [2,3,4].
+
+**Scenario 3: Same-Column Reorder (Move Down)**
+- Setup: Column A has tasks [0: "A", 1: "B", 2: "C", 3: "D"].
+- Action: Move task "B" (currently at position 1) to position 3.
+- Verify:
+  - Column A tasks are now [0: "A", 1: "C", 2: "D", 3: "B"].
+  - Tasks "C", "D" shifted from [2,3] to [1,2].
+
+**Scenario 4: Cross-Project Move Attempt**
+- Setup: Project X has column A with task "T1". Project Y has column B.
+- Action: Move task "T1" from column A to column B.
+- Verify: Returns 400 Bad Request with "Cannot move task to a column in a different project."
+
+**Scenario 5: Invalid TaskOrder (Out of Range)**
+- Setup: Column A has 3 tasks (TaskOrder 0, 1, 2). Moving task from column B.
+- Action: Move task to column A at position 5.
+- Verify: Returns 400 Bad Request with "TaskOrder is invalid."
+
+---
+
+## 7. Known Caveats
+
+| # | Caveat | Impact | Mitigation |
+|---|--------|--------|-----------|
+| 1 | **No unique constraint on TaskOrder** | Two concurrent moves to the same column could produce duplicate TaskOrder values. | Race window is small. `OrderBy(t => t.TaskOrder)` produces stable sort. Documented as known limitation for MVP. Future issue can add optimistic concurrency control. |
+| 2 | **No task history/audit log** | No record of task movements (who moved what, when). | Out of scope. Future issue can add audit table. |
+| 3 | **No undo/redo** | Users cannot revert a move operation. | Out of scope. Frontend can implement local undo via caching. |
+| 4 | **Last write wins** | If two users move the same task simultaneously, the second move overwrites the first. | EF Core's default concurrency model. Future issue can add row versioning via `[Timestamp]` property. |
+| 5 | **No bulk move** | Cannot move multiple tasks in a single request. | Intentionally deferred to future issue (bulk operations add complexity). |
+| 6 | **Same-column no-op returns 200 OK** | Moving a task to its current position returns success with no database changes. | Intentional: simplifies frontend logic (idempotent operation). |
+| 7 | **TaskOrder validation error message is generic** | Service returns "TaskOrder is invalid." without distinguishing "negative" vs "out of range". | Intentional: reduces error handling complexity. DTO-level validation already catches negative values; service-level check only catches out-of-range (upper bound). |
+| 8 | **No WIP limits** | No enforcement of work-in-progress limits per column. | Out of scope for Issue #47. Future enhancement. |
+
+---
+
+## 8. Design Validation (Self-Check)
+
+| Check | Question | Status |
+|-------|----------|--------|
+| **Namespaces** | Do all referenced namespaces match `RootNamespace = KanbAI_Core` and existing conventions? | ✅ Pass - `KanbAI_Core.DTOs`, `KanbAI_Core.Services.Tasks`, `KanbAI_Core.Controllers` |
+| **Folder Paths** | Do all file paths reference real folders, or are "create new" steps included? | ✅ Pass - `DTOs/`, `Services/Tasks/`, `Controllers/` already exist |
+| **Dependencies** | Are all required NuGet packages already in the `.csproj`, or are install steps included? | ✅ Pass - `Microsoft.EntityFrameworkCore`, `Microsoft.AspNetCore.Authentication.JwtBearer`, `System.ComponentModel.DataAnnotations` all present; no new packages |
+| **Naming Conflicts** | Do any new class/enum names conflict with existing types? | ✅ Pass - `MoveTaskDto`, `MoveTaskResult` are new names; `TaskController`, `TaskService`, `ITaskService` are existing types being extended (not replaced) |
+| **BaseEntity Compliance** | Do new entities inherit from `BaseEntity`? | ✅ N/A - no new entities; `KanbanTask` already inherits from `BaseEntity` |
+| **Code Standards** | File-scoped namespaces, no blocking async, constructor injection, `AsNoTracking` on reads? | ✅ Pass - verified in spec sections 4 & 5. Note: task and column loads are **tracked** (not AsNoTracking) because we mutate entities |
+| **Security** | No hardcoded secrets; no PII in logs; authorization enforced; mass-assignment prevented via DTO; input validation on DTO + service? | ✅ Pass - only `userId`/`taskId`/`columnId` (GUIDs) in logs; no PII; authorization via project membership check; DTOs bound, not entities; validation at DTO level ([Range(0, int.MaxValue)]) and service level (upper bound check) |
+
+**Result:** All checks pass. Design is ready for implementation.
+
+---
+
+**Document Status:** Ready for Implementation
+**Last Updated:** 2026-04-27
+**Next Steps:** @agent_developer should read this tech spec and begin implementation following Section 5 strictly.
+
+The technical specification is saved. You can now instruct the developer to read the tech spec and begin implementation.
+
+---
+
+## 9. Development Status
+
+**Developer:** @agent_developer
+**Completed:** 2026-04-27
+
+### 9.1 Files Created
+
+| File | Purpose |
+|------|---------|
+| [KanbAI-Core/KanbAI-Core/DTOs/MoveTaskDto.cs](../../KanbAI-Core/KanbAI-Core/DTOs/MoveTaskDto.cs) | Request DTO for the task move endpoint. `required Guid ColumnId` + `required int TaskOrder` with `[Range(0, int.MaxValue)]`. |
+| [KanbAI-Core/KanbAI-Core/Services/Tasks/MoveTaskResult.cs](../../KanbAI-Core/KanbAI-Core/Services/Tasks/MoveTaskResult.cs) | Discriminator enum for move outcomes (`Success`, `TaskNotFound`, `UserNotProjectMember`, `TargetColumnNotFound`, `CrossProjectMove`, `InvalidTaskOrder`). |
+
+### 9.2 Files Modified
+
+| File | Change |
+|------|--------|
+| [KanbAI-Core/KanbAI-Core/Services/Tasks/ITaskService.cs](../../KanbAI-Core/KanbAI-Core/Services/Tasks/ITaskService.cs) | Added `MoveTaskAsync(Guid taskId, MoveTaskDto dto, Guid userId)` signature with XML documentation. |
+| [KanbAI-Core/KanbAI-Core/Services/Tasks/TaskService.cs](../../KanbAI-Core/KanbAI-Core/Services/Tasks/TaskService.cs) | Implemented `MoveTaskAsync` per Section 4.3 algorithm: validate negative TaskOrder, load task with eager `Column -> Project -> Members`, project membership check, load target column (if different) with cross-project guard, upper-bound range validation (different-column: `<= count`; same-column: `<= count - 1`), no-op short circuit, then branching recalculation — cross-column decrements source-tail / increments target-head, same-column up/down adjusts the affected window — and a single `SaveChangesAsync()` for atomicity. |
+| [KanbAI-Core/KanbAI-Core/Controllers/TaskController.cs](../../KanbAI-Core/KanbAI-Core/Controllers/TaskController.cs) | Added `PUT /api/Task/{taskId}/move` endpoint (`MoveTask`) that forwards to `ITaskService.MoveTaskAsync` and maps `MoveTaskResult` values to HTTP status codes (200 / 400 / 403 / 404 / 500) using the existing `ApiResponse` helpers. Reuses `GetCurrentUserId()`. |
+
+### 9.3 Build & Test Results
+
+- **Build:** `dotnet build --no-incremental` → `Build succeeded. 0 Warning(s) 0 Error(s)`.
+- **Tests:** `dotnet test --verbosity quiet` → **340 passed, 0 failed, 2 skipped** (342 total). No pre-existing failures; no new failures introduced by the change.
+
+### 9.4 Infrastructure Notes
+
+- No new NuGet packages, no EF Core migrations, no schema changes, no DI wiring changes required. The existing `ITaskService` DI registration (from Issue #46) covers the new method.
+- No workarounds or test-only infrastructure were added.
+
+### 9.5 Edge Cases for QA
+
+1. **No-op same-position move** — `MoveTaskAsync` returns `Success` with the unchanged task when `ColumnId == task.ColumnId && TaskOrder == task.TaskOrder`. The method exits BEFORE `SaveChangesAsync()`, so `UpdatedAt` is not bumped and no UPDATE statements are emitted. Verify behavior matches spec (Section 7, Caveat 6) and that tests do not assert on `UpdatedAt` for this path.
+2. **Sequential TaskOrder invariant** — After any cross-column or same-column move, both affected columns must have `TaskOrder` values `0, 1, 2, ...` with no gaps and no duplicates. This is the key acceptance criterion; assert by querying each column ordered by `TaskOrder` and comparing to the expected index sequence.
+3. **Boundary TaskOrders** — Explicitly test:
+   - `TaskOrder = 0` (insert at top of target column).
+   - `TaskOrder = targetColumnCount` (append to a *different* column — valid, creates position = new count).
+   - `TaskOrder = targetColumnCount` for a *same-column* reorder — INVALID (must be `<= count - 1`), returns `InvalidTaskOrder`.
+4. **Same-column move up vs move down** — The two branches use different predicates (`>= new && < old` vs `> old && <= new`). Cover both directions and confirm the moved task itself is not double-adjusted (it is mutated only after the affected-window update).
+5. **Cross-project move** — Ensure the 400 path triggers when the target column's `ProjectId` differs from the task's current column's `ProjectId`, even if the caller *is* a member of the source project.
+6. **DTO validation vs service validation** — `[Range(0, int.MaxValue)]` on `TaskOrder` blocks negatives at the model-binding layer (HTTP 400 with ModelState errors). The service's `dto.TaskOrder < 0` guard is a defensive duplicate for direct service callers (unit tests). Both paths should be exercised.
+7. **Authorization precedence** — The service checks membership BEFORE loading the target column, so a non-member attempting a cross-project move will receive `UserNotProjectMember` (403), not `CrossProjectMove` (400). Tests should reflect this ordering.
+8. **Concurrency caveat** — No optimistic concurrency control; concurrent moves to the same column can produce duplicate `TaskOrder` values (Caveat 1). Out of scope to fix, but QA may want to document a reproduction for future work.
+
+---
+
+## 10. QA Status
+
+**QA Tester:** @agent_tester_qa
+**Completed:** 2026-04-27
+
+### 10.1 Test Files Created
+
+| Test File | Type | Coverage |
+|-----------|------|----------|
+| [KanbAI-Core/KanbAI-Core.Tests/Services/Tasks/TaskServiceMoveTests.cs](../../KanbAI-Core/KanbAI-Core.Tests/Services/Tasks/TaskServiceMoveTests.cs) | Unit (EF Core In-Memory) | 16 tests covering the `MoveTaskAsync` algorithm — cross-column moves (ColumnId/TaskOrder update, source decrement, target increment, append-to-end boundary), same-column reorder (move up, move down, same-position no-op), 404/403 paths (task not found, user not project member, target column not found), cross-project guard, TaskOrder validation (negative, exceeds target count, exceeds same-column count), and the sequential-invariant property across three back-to-back moves. |
+| [KanbAI-Core/KanbAI-Core.Tests/Controllers/TaskControllerTests.cs](../../KanbAI-Core/KanbAI-Core.Tests/Controllers/TaskControllerTests.cs) (extended) | Unit (mocked service) | 8 new tests: all six `MoveTaskResult → HTTP` mappings (200 / 404 / 403 / 404 / 400 / 400) plus two `MoveTaskDto` DataAnnotations tests (negative TaskOrder fails, TaskOrder=0 boundary passes). |
+| [KanbAI-Core/KanbAI-Core.Tests/Integration/TaskApiIntegrationTests.cs](../../KanbAI-Core/KanbAI-Core.Tests/Integration/TaskApiIntegrationTests.cs) (extended) | Integration (WebApplicationFactory) | 3 new tests: `PutMoveTask_Unauthenticated_Returns401`, `PutMoveTask_MissingColumnId_Returns400`, `PutMoveTask_NegativeTaskOrder_Returns400`. |
+
+### 10.2 Test Results
+
+- **Build:** `dotnet build` → `Build succeeded. 0 Warning(s) 0 Error(s)`.
+- **Tests:** `dotnet test --verbosity quiet` → **366 passed, 0 failed, 2 skipped** (368 total).
+- **Delta vs Issue #46 baseline:** +26 new tests (340 → 366). No pre-existing tests were broken.
+
+### 10.3 Acceptance Criteria Coverage
+
+| Acceptance Criterion | Covered By |
+|----------------------|------------|
+| PUT `/api/Task/{taskId}/move` endpoint exists, [Authorize] enforced | `PutMoveTask_Unauthenticated_Returns401` |
+| 404 if task does not exist | `MoveTaskAsync_TaskNotFound_ReturnsTaskNotFound`, `MoveTask_ServiceReturnsTaskNotFound_Returns404` |
+| 404 if target column does not exist | `MoveTaskAsync_TargetColumnNotFound_ReturnsTargetColumnNotFound`, `MoveTask_ServiceReturnsTargetColumnNotFound_Returns404` |
+| 403 if user is not a project member | `MoveTaskAsync_UserNotProjectMember_ReturnsUserNotProjectMember`, `MoveTask_ServiceReturnsUserNotProjectMember_Returns403` |
+| 400 if target column is in a different project | `MoveTaskAsync_CrossProjectMove_ReturnsCrossProjectMove`, `MoveTask_ServiceReturnsCrossProjectMove_Returns400` |
+| Cross-column move: ColumnId + TaskOrder updated | `MoveTaskAsync_DifferentColumn_UpdatesColumnIdAndTaskOrder` |
+| Cross-column move: source column gap removed | `MoveTaskAsync_DifferentColumn_RecalculatesSourceColumnOrders` |
+| Cross-column move: target column makes room | `MoveTaskAsync_DifferentColumn_RecalculatesTargetColumnOrders` |
+| Same-column reorder (move up) | `MoveTaskAsync_SameColumn_MoveUp_RecalculatesOrders` |
+| Same-column reorder (move down) | `MoveTaskAsync_SameColumn_MoveDown_RecalculatesOrders` |
+| Same-position no-op succeeds | `MoveTaskAsync_SameColumn_SamePosition_NoOp` |
+| TaskOrder sequential with no gaps after multiple moves | `MoveTaskAsync_MultipleSequentialMoves_MaintainsSequentialOrders` |
+| Negative TaskOrder rejected (DTO-level) | `MoveTaskDto_NegativeTaskOrder_FailsDataAnnotationsValidation`, `PutMoveTask_NegativeTaskOrder_Returns400` |
+| Negative TaskOrder rejected (service-level defensive) | `MoveTaskAsync_InvalidTaskOrder_Negative_ReturnsInvalidTaskOrder` |
+| TaskOrder > target column count (cross-column) | `MoveTaskAsync_InvalidTaskOrder_ExceedsTargetColumnCount_ReturnsInvalidTaskOrder` |
+| TaskOrder > column count − 1 (same-column) | `MoveTaskAsync_InvalidTaskOrder_ExceedsSameColumnCount_ReturnsInvalidTaskOrder` |
+| Append to end of a different column (TaskOrder = count) | `MoveTaskAsync_DifferentColumn_AppendToEnd_AddsAtBoundary` |
+| Missing ColumnId → 400 via model binding | `PutMoveTask_MissingColumnId_Returns400` |
+
+### 10.4 Bugs Found & Fixed
+
+None. The implementation matched the tech spec exactly on first review and all 26 new tests passed without requiring any production-code changes.
+
+### 10.5 Outstanding Issues
+
+None. Known limitations from Section 7 (no optimistic concurrency, no audit log, no WIP limits) are out of scope for Issue #47 and explicitly deferred to future work.
+
+---
+
+QA testing is complete. All tests pass and the implementation meets the acceptance criteria.


### PR DESCRIPTION
- Introduces `PUT /api/Task/{taskId}/move` endpoint for task movement and reordering.
- Implements `MoveTaskAsync` in `TaskService` with automatic `TaskOrder` recalculation for affected tasks across columns or within the same column.
- Enforces project membership-based authorization and prevents cross-project task moves.
- Adds `MoveTaskDto` for requests and `MoveTaskResult` enum for service outcomes.
- Includes comprehensive unit and integration tests covering various move scenarios and edge cases.
- Updates documentation and Claude agent settings.

Fixes #47